### PR TITLE
Add invsee and seen commands

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -51,6 +51,8 @@ import at.sleazlee.bmessentials.vot.VoteCommand;
 import at.sleazlee.bmessentials.votesystem.BMVote;
 import at.sleazlee.bmessentials.votesystem.TestVoteTabCompleter;
 import at.sleazlee.bmessentials.wild.*;
+import at.sleazlee.bmessentials.playerutils.InvseeCommand;
+import at.sleazlee.bmessentials.playerutils.SeenCommand;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -309,6 +311,12 @@ public class BMEssentials extends JavaPlugin {
             // Anvil
             this.getCommand("anvil").setExecutor(new AnvilCommand());
         }
+
+        // Inventory tools
+        InvseeCommand invsee = new InvseeCommand(this);
+        getCommand("invsee").setExecutor(invsee);
+        getServer().getPluginManager().registerEvents(invsee, this);
+        getCommand("seen").setExecutor(new SeenCommand());
 
         // Velocity Tell System
         if (config.getBoolean("Systems.VTell.Enabled")) {

--- a/src/main/java/at/sleazlee/bmessentials/playerutils/InvseeCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/playerutils/InvseeCommand.java
@@ -1,0 +1,134 @@
+package at.sleazlee.bmessentials.playerutils;
+
+import de.tr7zw.changeme.nbtapi.NBTCompound;
+import de.tr7zw.changeme.nbtapi.NBTFile;
+import de.tr7zw.changeme.nbtapi.NBTItem;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Command to view and edit another player's inventory.
+ */
+public class InvseeCommand implements CommandExecutor, Listener {
+
+    private final JavaPlugin plugin;
+    private final MiniMessage mm = MiniMessage.miniMessage();
+    private final Map<UUID, UUID> viewers = new HashMap<>();
+
+    public InvseeCommand(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(mm.deserialize("<red>This command can only be used by players.</red>"));
+            return true;
+        }
+        if (!player.hasPermission("bm.invsee.use")) {
+            player.sendMessage(mm.deserialize("<red>You do not have permission to use this command.</red>"));
+            return true;
+        }
+        if (args.length != 1) {
+            player.sendMessage(mm.deserialize("<gray>Usage: /invsee <player></gray>"));
+            return true;
+        }
+
+        String targetName = args[0];
+        Player targetOnline = Bukkit.getPlayerExact(targetName);
+        if (targetOnline != null) {
+            Inventory inv = Bukkit.createInventory(null, 54, targetOnline.getName() + "'s Inventory");
+            inv.setContents(targetOnline.getInventory().getContents());
+            player.openInventory(inv);
+            viewers.put(player.getUniqueId(), targetOnline.getUniqueId());
+            return true;
+        }
+
+        OfflinePlayer targetOffline = Bukkit.getOfflinePlayer(targetName);
+        if (!targetOffline.hasPlayedBefore()) {
+            player.sendMessage(mm.deserialize("<red>Player not found.</red>"));
+            return true;
+        }
+
+        Inventory inv = loadOfflineInventory(targetOffline);
+        player.openInventory(inv);
+        viewers.put(player.getUniqueId(), targetOffline.getUniqueId());
+        return true;
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        UUID viewerId = event.getPlayer().getUniqueId();
+        UUID targetId = viewers.remove(viewerId);
+        if (targetId == null) return;
+
+        Player targetOnline = Bukkit.getPlayer(targetId);
+        Inventory inv = event.getInventory();
+
+        if (targetOnline != null) {
+            ItemStack[] contents = Arrays.copyOf(inv.getContents(), targetOnline.getInventory().getContents().length);
+            targetOnline.getInventory().setContents(contents);
+            targetOnline.updateInventory();
+        } else {
+            OfflinePlayer targetOffline = Bukkit.getOfflinePlayer(targetId);
+            saveOfflineInventory(targetOffline, inv);
+        }
+    }
+
+    private Inventory loadOfflineInventory(OfflinePlayer off) {
+        Inventory inv = Bukkit.createInventory(null, 54, off.getName() + "'s Inventory");
+        try {
+            File dataFile = new File(Bukkit.getWorlds().get(0).getWorldFolder(), "playerdata/" + off.getUniqueId() + ".dat");
+            if (!dataFile.exists()) {
+                return inv;
+            }
+            NBTFile nbt = new NBTFile(dataFile);
+            List<NBTCompound> list = nbt.getCompoundList("Inventory");
+            for (NBTCompound tag : list) {
+                int slot = tag.getByte("Slot");
+                ItemStack item = NBTItem.convertNBTCompoundToItemStack(tag);
+                if (slot >= 0 && slot < inv.getSize()) {
+                    inv.setItem(slot, item);
+                }
+            }
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to load inventory for " + off.getName());
+        }
+        return inv;
+    }
+
+    private void saveOfflineInventory(OfflinePlayer off, Inventory inv) {
+        try {
+            File dataFile = new File(Bukkit.getWorlds().get(0).getWorldFolder(), "playerdata/" + off.getUniqueId() + ".dat");
+            if (!dataFile.exists()) return;
+            NBTFile nbt = new NBTFile(dataFile);
+            List<NBTCompound> list = new ArrayList<>();
+            for (int i = 0; i < inv.getSize(); i++) {
+                ItemStack item = inv.getItem(i);
+                if (item != null && item.getType().isItem()) {
+                    NBTCompound tag = NBTItem.convertItemtoNBT(item).getCompound();
+                    tag.setByte("Slot", (byte) i);
+                    list.add(tag);
+                }
+            }
+            nbt.setCompoundList("Inventory", list);
+            nbt.save();
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to save inventory for " + off.getName());
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/playerutils/SeenCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/playerutils/SeenCommand.java
@@ -1,0 +1,63 @@
+package at.sleazlee.bmessentials.playerutils;
+
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Command to check when a player was last online.
+ */
+public class SeenCommand implements CommandExecutor {
+
+    private static final MiniMessage mm = MiniMessage.miniMessage();
+    private static final Set<String> HIDDEN = new HashSet<>(Arrays.asList("SleazLee", "Seyten"));
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length != 1) {
+            sender.sendMessage(mm.deserialize("<gray>Usage: /seen <player></gray>"));
+            return true;
+        }
+
+        String name = args[0];
+        if (HIDDEN.contains(name)) {
+            sender.sendMessage(mm.deserialize("<red>This player is untraceable.</red>"));
+            return true;
+        }
+
+        OfflinePlayer target = Bukkit.getOfflinePlayer(name);
+        if (target.isOnline()) {
+            sender.sendMessage(mm.deserialize("<gold><bold>Seen</bold> <gray>" + name + " is currently online.</gray>"));
+            return true;
+        }
+
+        if (!target.hasPlayedBefore()) {
+            sender.sendMessage(mm.deserialize("<red>Player not found.</red>"));
+            return true;
+        }
+
+        long last = target.getLastPlayed();
+        String ago = formatAgo(System.currentTimeMillis() - last);
+        sender.sendMessage(mm.deserialize("<gold><bold>Seen</bold> <gray>" + name + " was last online " + ago + " ago.</gray>"));
+        return true;
+    }
+
+    private String formatAgo(long diff) {
+        long days = diff / 86400000L;
+        long hours = (diff / 3600000L) % 24;
+        long mins = (diff / 60000L) % 60;
+        StringBuilder sb = new StringBuilder();
+        if (days > 0) sb.append(days).append("d ");
+        if (hours > 0) sb.append(hours).append("h ");
+        if (mins > 0) sb.append(mins).append("m");
+        if (sb.length() == 0) sb.append("just now");
+        return sb.toString().trim();
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -231,6 +231,15 @@ commands:
   chestsort:
     description: Changes ChestSort Settings.
 
+  invsee:
+    description: View and edit another player's inventory.
+    usage: /invsee <player>
+    permission: bm.invsee.use
+
+  seen:
+    description: Shows when a player was last online.
+    usage: /seen <player>
+
 
 permissions:
   bmessentials.vot.use:
@@ -251,4 +260,8 @@ permissions:
 
   bmessentials.eco.admin:
     description: Access to all economy admin commands
+    default: op
+
+  bm.invsee.use:
+    description: Allows the player to open other players' inventories.
     default: op


### PR DESCRIPTION
## Summary
- add `InvseeCommand` and `SeenCommand` for inventory viewing and last seen checks
- register new commands in plugin
- document commands and permission in `plugin.yml`

## Testing
- `mvn package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684061d52ae083329e6cceeb9c82fc5f