### PR TITLE
Fix AFK broadcast logic

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkCommand.java
@@ -41,8 +41,14 @@ public class AfkCommand implements CommandExecutor {
 
             Bukkit.broadcast(MiniMessage.miniMessage().deserialize(message));
             AfkManager.getInstance().updateLastAfkMessageTime(player);
-            AfkManager.getInstance().setBroadcastedAfk(player, true);
+        }
+
+        // Manage broadcast flag for future automatic messages.
+        if (newState) {
+            // Player entered AFK via command.
+            AfkManager.getInstance().setBroadcastedAfk(player, canSendMessage);
         } else {
+            // Player exited AFK via command.
             AfkManager.getInstance().setBroadcastedAfk(player, false);
         }
 

--- a/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkListener.java
+++ b/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkListener.java
@@ -45,8 +45,8 @@ public class AfkListener implements Listener {
             if (!alreadyBroadcast) {
                 String message = "<italic><gray>" + player.getName() + " is no longer AFK</gray></italic>";
                 Bukkit.broadcast(miniMessage.deserialize(message));
-                // Mark as broadcasted to prevent future duplicate messages.
-                AfkManager.getInstance().setBroadcastedAfk(player, true);
+                // Reset flag so future automatic AFK sessions don't broadcast.
+                AfkManager.getInstance().setBroadcastedAfk(player, false);
             }
         }
     }
@@ -82,8 +82,8 @@ public class AfkListener implements Listener {
             if (!alreadyBroadcast) {
                 String message = "<italic><gray>" + player.getName() + " is no longer AFK</gray></italic>";
                 Bukkit.broadcast(miniMessage.deserialize(message));
-                // Mark as broadcasted to prevent future duplicate messages.
-                AfkManager.getInstance().setBroadcastedAfk(player, true);
+                // Reset flag so future automatic AFK sessions don't broadcast.
+                AfkManager.getInstance().setBroadcastedAfk(player, false);
             }
         }
     }

--- a/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkManager.java
+++ b/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkManager.java
@@ -111,6 +111,8 @@ public class AfkManager {
                         String message = "<italic><gray>" + player.getName() + " is no longer AFK</gray></italic>";
                         Bukkit.broadcast(MiniMessage.miniMessage().deserialize(message));
                     }
+                    // Reset broadcast flag for the next AFK session.
+                    activity.setBroadcastedAfkMessage(false);
                 }
             } else {
                 // No significant movement detected. Check if the inactivity threshold has been reached.
@@ -118,6 +120,9 @@ public class AfkManager {
                     activity.setAfk(true);
                     // Notify the vote system that the player is now AFK.
                     VoteManager.getInstance().handlePlayerAfk(player);
+                    // Auto AFK should not trigger a "no longer AFK" broadcast unless the player
+                    // manually set themselves AFK again.
+                    activity.setBroadcastedAfkMessage(false);
                 }
             }
         }
@@ -172,6 +177,7 @@ public class AfkManager {
         activity.setLastLocation(player.getLocation());  // optional, if you still want to track location
         if (activity.isAfk()) {
             activity.setAfk(false);
+            activity.setBroadcastedAfkMessage(false);
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid "no longer AFK" spam when player never broadcast /afk
- reset broadcast flag when users leave AFK
- reset flag when system sets players AFK automatically