### PR TITLE
Fix AFK cleanup and messaging

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkListener.java
+++ b/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 /**
  * Listener to detect player activity events and update AFK status.
@@ -41,8 +42,8 @@ public class AfkListener implements Listener {
             AfkManager.getInstance().forceActive(player);
             VoteManager.getInstance().handlePlayerJoin(player);
 
-            // Broadcast "no longer AFK" message only once per AFK session.
-            if (!alreadyBroadcast) {
+            // Broadcast "no longer AFK" message only if an "AFK" message was sent.
+            if (alreadyBroadcast) {
                 String message = "<italic><gray>" + player.getName() + " is no longer AFK</gray></italic>";
                 Bukkit.broadcast(miniMessage.deserialize(message));
                 // Reset flag so future automatic AFK sessions don't broadcast.
@@ -78,13 +79,23 @@ public class AfkListener implements Listener {
             AfkManager.getInstance().forceActive(player);
             VoteManager.getInstance().handlePlayerJoin(player);
 
-            // Broadcast "no longer AFK" message only once per AFK session.
-            if (!alreadyBroadcast) {
+            // Broadcast "no longer AFK" message only if an "AFK" message was sent.
+            if (alreadyBroadcast) {
                 String message = "<italic><gray>" + player.getName() + " is no longer AFK</gray></italic>";
                 Bukkit.broadcast(miniMessage.deserialize(message));
                 // Reset flag so future automatic AFK sessions don't broadcast.
                 AfkManager.getInstance().setBroadcastedAfk(player, false);
             }
         }
+    }
+
+    /**
+     * Cleans up AFK data when a player leaves the server.
+     *
+     * @param event the player quit event
+     */
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        AfkManager.getInstance().removePlayer(event.getPlayer());
     }
 }

--- a/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkManager.java
+++ b/src/main/java/at/sleazlee/bmessentials/AFKSystem/AfkManager.java
@@ -180,5 +180,16 @@ public class AfkManager {
         }
     }
 
+    /**
+     * Removes all AFK related data for a player. This should be called when the
+     * player leaves the server to ensure stale AFK state isn't retained.
+     *
+     * @param player the player to remove
+     */
+    public void removePlayer(Player player) {
+        activityMap.remove(player.getUniqueId());
+        lastAfkCommandTime.remove(player.getUniqueId());
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- don't broadcast "no longer AFK" unless player previously broadcasted an AFK message
- remove AFK data when a player leaves the server

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dfd5d94bc8332adc6313c236525ce