### PR TITLE
Add SimplePortals system

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -54,6 +54,7 @@ import at.sleazlee.bmessentials.vot.VoteCommand;
 import at.sleazlee.bmessentials.votesystem.BMVote;
 import at.sleazlee.bmessentials.votesystem.TestVoteTabCompleter;
 import at.sleazlee.bmessentials.wild.*;
+import at.sleazlee.bmessentials.SimplePortals.*;
 import at.sleazlee.bmessentials.playerutils.InvseeCommand;
 import at.sleazlee.bmessentials.playerutils.InvseeTabCompleter;
 import at.sleazlee.bmessentials.playerutils.SeenCommand;
@@ -106,6 +107,10 @@ public class BMEssentials extends JavaPlugin {
 
     /** The instance of the Plugin Message Encryption Code. */
     private AESEncryptor aes;
+
+    // Instances used by the SimplePortals system
+    private WildCommand wildCommandInstance;
+    private HealCommand healCommandInstance;
 
     /**
      * Gets the instance of the main plugin class.
@@ -244,11 +249,11 @@ public class BMEssentials extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new NoFallDamage(), this);
 
             // Instantiate the command executor and tab completer, passing the WildData instance.
-            WildCommand wildCommand = new WildCommand(wildData, this);
+            wildCommandInstance = new WildCommand(wildData, this);
             WildTabCompleter wildTabCompleter = new WildTabCompleter(wildData);
 
             // Register the /wild command executor and tab completer.
-            this.getCommand("wild").setExecutor(wildCommand);
+            this.getCommand("wild").setExecutor(wildCommandInstance);
             this.getCommand("wild").setTabCompleter(wildTabCompleter);
 
             // Register the /version command
@@ -261,13 +266,23 @@ public class BMEssentials extends JavaPlugin {
             getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled Spawn Systems");
 
             this.getCommand("firstjoinmessage").setExecutor(new FirstJoinCommand(this));
-            this.getCommand("springsheal").setExecutor(new HealCommand(this));
+            healCommandInstance = new HealCommand(this);
 
             AltarManager altarManager = new AltarManager(this);
             getServer().getPluginManager().registerEvents(altarManager, this);
             HealingSprings.startHealingSpringsAmbient(this);
             WishingWell.startWishingWellAmbient(this);
             Obelisk.startObeliskAmbient(this);
+        }
+
+        // SimplePortals System
+        if (config.getBoolean("Systems.SimplePortals.Enabled")) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled SimplePortals");
+            if (wildCommandInstance != null && healCommandInstance != null) {
+                new SimplePortals(this, wildCommandInstance, healCommandInstance);
+            } else {
+                getLogger().warning("SimplePortals could not be initialized because Wild or SpawnSystems is disabled.");
+            }
         }
 
         // Common Commands

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/HealingSpringsHandler.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/HealingSpringsHandler.java
@@ -1,0 +1,64 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.session.MoveType;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.handler.FlagValueChangeHandler;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.entity.Player;
+
+/**
+ * Handler that triggers healing when a player enters a region with the entered-healing-springs flag set.
+ */
+public class HealingSpringsHandler extends FlagValueChangeHandler<Boolean> {
+
+    private final HealCommand healCommand;
+
+    public static class Factory extends Handler.Factory<HealingSpringsHandler> {
+        private final HealCommand healCommand;
+        public Factory(HealCommand healCommand) {
+            this.healCommand = healCommand;
+        }
+        @Override
+        public HealingSpringsHandler create(Session session) {
+            return new HealingSpringsHandler(session, healCommand);
+        }
+    }
+
+    private HealingSpringsHandler(Session session, HealCommand healCommand) {
+        super(session, SimplePortals.ENTERED_HEALING_SPRINGS);
+        this.healCommand = healCommand;
+    }
+
+    @Override
+    protected void onInitialValue(LocalPlayer player, ApplicableRegionSet set, Boolean value) {
+        if (Boolean.TRUE.equals(value)) {
+            run(player);
+        }
+    }
+
+    @Override
+    protected boolean onSetValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                 Boolean currentValue, Boolean lastValue, MoveType moveType) {
+        if (Boolean.TRUE.equals(currentValue) && !Boolean.TRUE.equals(lastValue)) {
+            run(player);
+        }
+        return true;
+    }
+
+    @Override
+    protected boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                    Boolean lastValue, MoveType moveType) {
+        return true;
+    }
+
+    private void run(LocalPlayer localPlayer) {
+        Player bukkit = localPlayer.getPlayer();
+        if (bukkit != null) {
+            healCommand.checkAndExecute(bukkit);
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SendToWildHandler.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SendToWildHandler.java
@@ -1,0 +1,64 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.wild.WildCommand;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.session.MoveType;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.handler.FlagValueChangeHandler;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.entity.Player;
+
+/**
+ * Handler that teleports a player to the wild when entering a region with the send-to-wild flag set to allow.
+ */
+public class SendToWildHandler extends FlagValueChangeHandler<Boolean> {
+
+    private final WildCommand wildCommand;
+
+    public static class Factory extends Handler.Factory<SendToWildHandler> {
+        private final WildCommand wildCommand;
+        public Factory(WildCommand wildCommand) {
+            this.wildCommand = wildCommand;
+        }
+        @Override
+        public SendToWildHandler create(Session session) {
+            return new SendToWildHandler(session, wildCommand);
+        }
+    }
+
+    private SendToWildHandler(Session session, WildCommand wildCommand) {
+        super(session, SimplePortals.SEND_TO_WILD);
+        this.wildCommand = wildCommand;
+    }
+
+    @Override
+    protected void onInitialValue(LocalPlayer player, ApplicableRegionSet set, Boolean value) {
+        if (Boolean.TRUE.equals(value)) {
+            run(player);
+        }
+    }
+
+    @Override
+    protected boolean onSetValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                 Boolean currentValue, Boolean lastValue, MoveType moveType) {
+        if (Boolean.TRUE.equals(currentValue) && !Boolean.TRUE.equals(lastValue)) {
+            run(player);
+        }
+        return true;
+    }
+
+    @Override
+    protected boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                    Boolean lastValue, MoveType moveType) {
+        return true;
+    }
+
+    private void run(LocalPlayer localPlayer) {
+        Player bukkit = localPlayer.getPlayer();
+        if (bukkit != null) {
+            wildCommand.randomLocation(bukkit, "all");
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
@@ -1,0 +1,59 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.wild.WildCommand;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.session.SessionManager;
+
+/**
+ * Registers custom WorldGuard flags and session handlers for simple portal functionality.
+ */
+public class SimplePortals {
+
+    /** Flag that teleports players to the wild when they enter a region. */
+    public static StateFlag SEND_TO_WILD;
+
+    /** Flag that heals players when they enter the Healing Springs region. */
+    public static StateFlag ENTERED_HEALING_SPRINGS;
+
+    /**
+     * Initialise the SimplePortals system.
+     *
+     * @param plugin       reference to the main plugin
+     * @param wildCommand  instance of WildCommand used for teleportation
+     * @param healCommand  instance of HealCommand used for healing
+     */
+    public SimplePortals(BMEssentials plugin, WildCommand wildCommand, HealCommand healCommand) {
+        registerFlags();
+        registerHandlers(wildCommand, healCommand);
+    }
+
+    private void registerFlags() {
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+
+        SEND_TO_WILD = new StateFlag("send-to-wild", false);
+        ENTERED_HEALING_SPRINGS = new StateFlag("entered-healing-springs", false);
+
+        try {
+            registry.register(SEND_TO_WILD);
+        } catch (FlagConflictException e) {
+            SEND_TO_WILD = (StateFlag) registry.get("send-to-wild");
+        }
+
+        try {
+            registry.register(ENTERED_HEALING_SPRINGS);
+        } catch (FlagConflictException e) {
+            ENTERED_HEALING_SPRINGS = (StateFlag) registry.get("entered-healing-springs");
+        }
+    }
+
+    private void registerHandlers(WildCommand wildCommand, HealCommand healCommand) {
+        SessionManager sessionManager = WorldGuard.getInstance().getPlatform().getSessionManager();
+        sessionManager.registerHandler(new SendToWildHandler.Factory(wildCommand), null);
+        sessionManager.registerHandler(new HealingSpringsHandler.Factory(healCommand), null);
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
@@ -5,9 +5,6 @@ import at.sleazlee.bmessentials.Scheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -15,7 +12,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HealCommand implements CommandExecutor {
+public class HealCommand {
 
 	private final BMEssentials plugin;
 
@@ -33,25 +30,8 @@ public class HealCommand implements CommandExecutor {
 		this.plugin = plugin;
 	}
 
-	@Override
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		// Ensure the command is executed with at least one argument
-		if (args.length > 0) {
-			String playerName = args[0];
-			Player player = Bukkit.getPlayer(playerName);
 
-			if (player != null && sender.hasPermission("bmessentials.heal")) {
-				checkAndExecute(player);
-			} else {
-				sender.sendMessage("§cPlayer not found, not online, or you lack permissions.");
-			}
-		} else {
-			sender.sendMessage("§cUsage: /" + label + " <player>");
-		}
-		return true;
-	}
-
-	private void checkAndExecute(Player player) {
+        public void checkAndExecute(Player player) {
 		UUID playerUUID = player.getUniqueId();
 		long currentTime = System.currentTimeMillis();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -107,6 +107,10 @@ Systems:
       #   Name: <Region Name>
       #   Return: <Return Value>
 
+  # Enables the SimplePortals system.
+  SimplePortals:
+    Enabled: true
+
   # Enables spawn only systems.
   SpawnSystems:
     Enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -111,9 +111,6 @@ commands:
     description: Toggle your BlueMap visibility
     usage: /maps <toggle|show|hide>
 
-  springsheal:
-    description: Heals the player.
-    usage: /springsheal
 
   playtime:
     description: Shows the player their current Playtime.


### PR DESCRIPTION
## Summary
- add new SimplePortals system using WorldGuard flags
- trigger wild teleport and healing springs effects via session handlers
- remove old `/springsheal` command
- expose healing logic for reuse
- wire SimplePortals into plugin when enabled

## Testing
- `javac -classpath /tmp/worldguard.jar src/main/java/at/sleazlee/bmessentials/SimplePortals/*.java` *(fails: package dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e045448ec8332b19d15989bb329b7