### PR TITLE
Add SimplePortals system

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -36,7 +36,7 @@ import at.sleazlee.bmessentials.Punish.UnMuteCommand;
 import at.sleazlee.bmessentials.Punish.VelocityMutePlayer;
 import at.sleazlee.bmessentials.PurpurFeatures.*;
 import at.sleazlee.bmessentials.SpawnSystems.FirstJoinCommand;
-import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.SimplePortals.SimplePortals;
 import at.sleazlee.bmessentials.VTell.VTellCommand;
 import at.sleazlee.bmessentials.art.Art;
 import at.sleazlee.bmessentials.bmefunctions.BMECommandExecutor;
@@ -255,13 +255,18 @@ public class BMEssentials extends JavaPlugin {
             getCommand("version").setExecutor(new ChunkVersion(wildData, this));
         }
 
+        // SimplePortals System
+        if (config.getBoolean("Systems.SimplePortals.Enabled")) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled SimplePortals");
+            new SimplePortals(this);
+        }
+
         // Spawn Systems
         if (config.getBoolean("Systems.SpawnSystems.Enabled")) {
             // Add the system enabled message.
             getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled Spawn Systems");
 
             this.getCommand("firstjoinmessage").setExecutor(new FirstJoinCommand(this));
-            this.getCommand("springsheal").setExecutor(new HealCommand(this));
 
             AltarManager altarManager = new AltarManager(this);
             getServer().getPluginManager().registerEvents(altarManager, this);

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
@@ -1,0 +1,59 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.wild.WildCommand;
+import at.sleazlee.bmessentials.wild.WildData;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.flags.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.session.SessionManager;
+
+/**
+ * Initializes custom WorldGuard flags and session handlers for simple portal logic.
+ */
+public class SimplePortals {
+
+    /** Flag that triggers a random wild teleport when entering a region. */
+    public static final StateFlag SEND_TO_WILD = new StateFlag("send-to-wild", false);
+
+    /** Flag that triggers healing when entering a region. */
+    public static final StateFlag ENTERED_HEALING_SPRINGS = new StateFlag("entered-healing-springs", false);
+
+    private final BMEssentials plugin;
+
+    /**
+     * Constructs the SimplePortals system and registers flags and handlers.
+     *
+     * @param plugin main plugin instance
+     */
+    public SimplePortals(BMEssentials plugin) {
+        this.plugin = plugin;
+        registerFlags();
+        registerHandler();
+    }
+
+    private void registerFlags() {
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+        try {
+            registry.register(SEND_TO_WILD);
+        } catch (FlagConflictException ignored) {
+            plugin.getLogger().warning("send-to-wild flag already registered");
+        }
+        try {
+            registry.register(ENTERED_HEALING_SPRINGS);
+        } catch (FlagConflictException ignored) {
+            plugin.getLogger().warning("entered-healing-springs flag already registered");
+        }
+    }
+
+    private void registerHandler() {
+        WildData wildData = new WildData(plugin);
+        WildCommand wildCommand = new WildCommand(wildData, plugin);
+        HealCommand healCommand = new HealCommand();
+
+        SessionManager manager = WorldGuard.getInstance().getPlatform().getSessionManager();
+        manager.registerHandler(new SimplePortalsFlagHandler.Factory(wildCommand, healCommand), null);
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortalsFlagHandler.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortalsFlagHandler.java
@@ -1,0 +1,68 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.wild.WildCommand;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * WorldGuard session handler that checks for custom SimplePortals flags
+ * when players cross region boundaries.
+ */
+public class SimplePortalsFlagHandler extends Handler {
+
+    /** Factory used by WorldGuard to create handler instances. */
+    public static class Factory extends Handler.Factory<SimplePortalsFlagHandler> {
+        private final WildCommand wildCommand;
+        private final HealCommand healCommand;
+
+        public Factory(WildCommand wildCommand, HealCommand healCommand) {
+            super(SimplePortalsFlagHandler.class);
+            this.wildCommand = wildCommand;
+            this.healCommand = healCommand;
+        }
+
+        @Override
+        public SimplePortalsFlagHandler create(Session session) {
+            return new SimplePortalsFlagHandler(session, wildCommand, healCommand);
+        }
+    }
+
+    private final WildCommand wildCommand;
+    private final HealCommand healCommand;
+
+    private SimplePortalsFlagHandler(Session session, WildCommand wildCommand, HealCommand healCommand) {
+        super(session);
+        this.wildCommand = wildCommand;
+        this.healCommand = healCommand;
+    }
+
+    @Override
+    public void initialize(LocalPlayer player, ApplicableRegionSet set) {
+        handle(player, set);
+    }
+
+    @Override
+    public void onCrossBoundary(LocalPlayer player, ApplicableRegionSet to, ApplicableRegionSet from, MoveType moveType) {
+        handle(player, to);
+    }
+
+    private void handle(LocalPlayer localPlayer, ApplicableRegionSet set) {
+        Player player = Bukkit.getPlayer(localPlayer.getUniqueId());
+        if (player == null) {
+            return;
+        }
+
+        if (set.testState(localPlayer, SimplePortals.SEND_TO_WILD)) {
+            wildCommand.randomLocation(player, "all");
+        }
+
+        if (set.testState(localPlayer, SimplePortals.ENTERED_HEALING_SPRINGS)) {
+            healCommand.checkAndExecute(player);
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
@@ -1,13 +1,9 @@
 package at.sleazlee.bmessentials.SpawnSystems;
 
-import at.sleazlee.bmessentials.BMEssentials;
 import at.sleazlee.bmessentials.Scheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -15,9 +11,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HealCommand implements CommandExecutor {
-
-	private final BMEssentials plugin;
+public class HealCommand {
 
 	// Existing cooldown map for 90-minute cooldown
 	private final Map<UUID, Long> mainCooldowns = new ConcurrentHashMap<>();
@@ -27,31 +21,13 @@ public class HealCommand implements CommandExecutor {
 	private final Map<UUID, Long> commandCooldowns = new ConcurrentHashMap<>();
 	private final long commandCooldownDuration = 10 * 1000; // 10 seconds in milliseconds
 
-	private final Random random = new Random();
+        private final Random random = new Random();
 
-	public HealCommand(BMEssentials plugin) {
-		this.plugin = plugin;
-	}
+        public HealCommand() {
+                // empty constructor
+        }
 
-	@Override
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		// Ensure the command is executed with at least one argument
-		if (args.length > 0) {
-			String playerName = args[0];
-			Player player = Bukkit.getPlayer(playerName);
-
-			if (player != null && sender.hasPermission("bmessentials.heal")) {
-				checkAndExecute(player);
-			} else {
-				sender.sendMessage("§cPlayer not found, not online, or you lack permissions.");
-			}
-		} else {
-			sender.sendMessage("§cUsage: /" + label + " <player>");
-		}
-		return true;
-	}
-
-	private void checkAndExecute(Player player) {
+        public void checkAndExecute(Player player) {
 		UUID playerUUID = player.getUniqueId();
 		long currentTime = System.currentTimeMillis();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -235,3 +235,7 @@ Systems:
   # Enables the Lands TP Fix System
   LandsTPFix:
     Enabled: true
+
+  # Enables the SimplePortals System
+  SimplePortals:
+    Enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -111,9 +111,6 @@ commands:
     description: Toggle your BlueMap visibility
     usage: /maps <toggle|show|hide>
 
-  springsheal:
-    description: Heals the player.
-    usage: /springsheal
 
   playtime:
     description: Shows the player their current Playtime.


### PR DESCRIPTION
## Summary
- create SimplePortals system using WorldGuard custom flags
- hook SimplePortals into plugin startup when enabled in config
- refactor HealCommand to be callable without a command
- remove unused `/springsheal` command
- expose new config option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e04df5d948332beb28e4d2d1c8dba