### PR TITLE
Add SimplePortals system

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -37,6 +37,7 @@ import at.sleazlee.bmessentials.Punish.VelocityMutePlayer;
 import at.sleazlee.bmessentials.PurpurFeatures.*;
 import at.sleazlee.bmessentials.SpawnSystems.FirstJoinCommand;
 import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.SimplePortals.SimplePortals;
 import at.sleazlee.bmessentials.VTell.VTellCommand;
 import at.sleazlee.bmessentials.art.Art;
 import at.sleazlee.bmessentials.bmefunctions.BMECommandExecutor;
@@ -107,13 +108,22 @@ public class BMEssentials extends JavaPlugin {
     /** The instance of the Plugin Message Encryption Code. */
     private AESEncryptor aes;
 
+    private WildCommand wildCommand;
+    private HealCommand healCommand;
+    private SimplePortals simplePortals;
+
     /**
      * Gets the instance of the main plugin class.
      *
      * @return the plugin instance
      */
-    public static BMEssentials getInstance() {
-        return getPlugin(BMEssentials.class);
+public static BMEssentials getInstance() {
+    return getPlugin(BMEssentials.class);
+}
+
+    @Override
+    public void onLoad() {
+        SimplePortals.registerFlags();
     }
 
     /**
@@ -244,11 +254,11 @@ public class BMEssentials extends JavaPlugin {
             getServer().getPluginManager().registerEvents(new NoFallDamage(), this);
 
             // Instantiate the command executor and tab completer, passing the WildData instance.
-            WildCommand wildCommand = new WildCommand(wildData, this);
+            this.wildCommand = new WildCommand(wildData, this);
             WildTabCompleter wildTabCompleter = new WildTabCompleter(wildData);
 
             // Register the /wild command executor and tab completer.
-            this.getCommand("wild").setExecutor(wildCommand);
+            this.getCommand("wild").setExecutor(this.wildCommand);
             this.getCommand("wild").setTabCompleter(wildTabCompleter);
 
             // Register the /version command
@@ -261,13 +271,23 @@ public class BMEssentials extends JavaPlugin {
             getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled Spawn Systems");
 
             this.getCommand("firstjoinmessage").setExecutor(new FirstJoinCommand(this));
-            this.getCommand("springsheal").setExecutor(new HealCommand(this));
+            this.healCommand = new HealCommand(this);
 
             AltarManager altarManager = new AltarManager(this);
             getServer().getPluginManager().registerEvents(altarManager, this);
             HealingSprings.startHealingSpringsAmbient(this);
             WishingWell.startWishingWellAmbient(this);
             Obelisk.startObeliskAmbient(this);
+        }
+
+        if (config.getBoolean("Systems.SimplePortals.Enabled")) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled SimplePortals");
+            if (this.wildCommand != null && this.healCommand != null) {
+                this.simplePortals = new SimplePortals(this.wildCommand, this.healCommand);
+                this.simplePortals.registerHandlers();
+            } else {
+                getLogger().warning("SimplePortals requires Wild and SpawnSystems to be enabled.");
+            }
         }
 
         // Common Commands

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
@@ -1,0 +1,139 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.wild.WildCommand;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.FlagRegistry;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.session.MoveType;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.SessionManager;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+
+/**
+ * A simple portal system leveraging WorldGuard regions and custom flags.
+ * When a player enters a region with one of the custom flags set to ALLOW,
+ * a specific method is executed.
+ */
+public class SimplePortals {
+
+    /** Flag that triggers a random wild teleport. */
+    public static StateFlag SEND_TO_WILD;
+    /** Flag that triggers the healing springs check. */
+    public static StateFlag ENTERED_HEALING_SPRINGS;
+
+    private final WildCommand wildCommand;
+    private final HealCommand healCommand;
+
+    public SimplePortals(WildCommand wildCommand, HealCommand healCommand) {
+        this.wildCommand = wildCommand;
+        this.healCommand = healCommand;
+    }
+
+    /**
+     * Register the custom flags with WorldGuard. Should be called during plugin load.
+     */
+    public static void registerFlags() {
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+
+        try {
+            StateFlag flag = new StateFlag("send-to-wild", false);
+            registry.register(flag);
+            SEND_TO_WILD = flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("send-to-wild");
+            if (existing instanceof StateFlag) {
+                SEND_TO_WILD = (StateFlag) existing;
+            }
+        }
+
+        try {
+            StateFlag flag = new StateFlag("entered-healing-springs", false);
+            registry.register(flag);
+            ENTERED_HEALING_SPRINGS = flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("entered-healing-springs");
+            if (existing instanceof StateFlag) {
+                ENTERED_HEALING_SPRINGS = (StateFlag) existing;
+            }
+        }
+    }
+
+    /**
+     * Register the session handlers that listen for region entry.
+     */
+    public void registerHandlers() {
+        SessionManager manager = WorldGuard.getInstance().getPlatform().getSessionManager();
+        manager.registerHandler(new SendToWildHandler.Factory(wildCommand), null);
+        manager.registerHandler(new HealingSpringsHandler.Factory(healCommand), null);
+    }
+
+    /** Handler for the send-to-wild flag. */
+    private static class SendToWildHandler extends Handler {
+        static class Factory extends Handler.Factory<SendToWildHandler> {
+            private final WildCommand wild;
+            Factory(WildCommand wild) { this.wild = wild; }
+            @Override
+            public SendToWildHandler create(Session session) {
+                return new SendToWildHandler(session, wild);
+            }
+        }
+        private final WildCommand wild;
+        SendToWildHandler(Session session, WildCommand wild) {
+            super(session);
+            this.wild = wild;
+        }
+        @Override
+        public boolean onCrossBoundary(LocalPlayer player, Location from, Location to,
+                                       ApplicableRegionSet toSet, Set<ProtectedRegion> entered,
+                                       Set<ProtectedRegion> exited, MoveType moveType) {
+            if (toSet.testState(player, SEND_TO_WILD)) {
+                Player bukkit = Bukkit.getPlayer(player.getUniqueId());
+                if (bukkit != null) {
+                    wild.randomLocation(bukkit, "all");
+                }
+            }
+            return true;
+        }
+    }
+
+    /** Handler for the entered-healing-springs flag. */
+    private static class HealingSpringsHandler extends Handler {
+        static class Factory extends Handler.Factory<HealingSpringsHandler> {
+            private final HealCommand heal;
+            Factory(HealCommand heal) { this.heal = heal; }
+            @Override
+            public HealingSpringsHandler create(Session session) {
+                return new HealingSpringsHandler(session, heal);
+            }
+        }
+        private final HealCommand heal;
+        HealingSpringsHandler(Session session, HealCommand heal) {
+            super(session);
+            this.heal = heal;
+        }
+        @Override
+        public boolean onCrossBoundary(LocalPlayer player, Location from, Location to,
+                                       ApplicableRegionSet toSet, Set<ProtectedRegion> entered,
+                                       Set<ProtectedRegion> exited, MoveType moveType) {
+            if (toSet.testState(player, ENTERED_HEALING_SPRINGS)) {
+                Player bukkit = Bukkit.getPlayer(player.getUniqueId());
+                if (bukkit != null) {
+                    heal.checkAndExecute(bukkit);
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
@@ -5,9 +5,7 @@ import at.sleazlee.bmessentials.Scheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
+
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -15,7 +13,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HealCommand implements CommandExecutor {
+public class HealCommand {
 
 	private final BMEssentials plugin;
 
@@ -33,25 +31,9 @@ public class HealCommand implements CommandExecutor {
 		this.plugin = plugin;
 	}
 
-	@Override
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		// Ensure the command is executed with at least one argument
-		if (args.length > 0) {
-			String playerName = args[0];
-			Player player = Bukkit.getPlayer(playerName);
 
-			if (player != null && sender.hasPermission("bmessentials.heal")) {
-				checkAndExecute(player);
-			} else {
-				sender.sendMessage("§cPlayer not found, not online, or you lack permissions.");
-			}
-		} else {
-			sender.sendMessage("§cUsage: /" + label + " <player>");
-		}
-		return true;
-	}
 
-	private void checkAndExecute(Player player) {
+        public void checkAndExecute(Player player) {
 		UUID playerUUID = player.getUniqueId();
 		long currentTime = System.currentTimeMillis();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -102,10 +102,14 @@ Systems:
         Name: "spawn"
         Return: "spawn"
 
-      # Add new regions as needed
-      # 3:
-      #   Name: <Region Name>
-      #   Return: <Return Value>
+  # Add new regions as needed
+  # 3:
+  #   Name: <Region Name>
+  #   Return: <Return Value>
+
+  # Enables SimplePortals integration.
+  SimplePortals:
+    Enabled: true
 
   # Enables spawn only systems.
   SpawnSystems:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -111,9 +111,6 @@ commands:
     description: Toggle your BlueMap visibility
     usage: /maps <toggle|show|hide>
 
-  springsheal:
-    description: Heals the player.
-    usage: /springsheal
 
   playtime:
     description: Shows the player their current Playtime.


### PR DESCRIPTION
## Summary
- add `SimplePortals` package with custom WorldGuard flags
- load flags on plugin load
- register SimplePortals if enabled
- expose `HealCommand.checkAndExecute` for portal use
- remove `/springsheal` command
- document new config entry

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e045448ec8332b19d15989bb329b7