### PR TITLE
Add SimplePortals system

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
@@ -1,0 +1,114 @@
+package at.sleazlee.bmessentials.SimplePortals;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
+import at.sleazlee.bmessentials.wild.WildCommand;
+import at.sleazlee.bmessentials.wild.WildData;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.session.MoveType;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.SessionManager;
+import com.sk89q.worldguard.session.handler.FlagValueChangeHandler;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.entity.Player;
+
+/**
+ * Registers simple portal handlers using WorldGuard custom flags.
+ */
+public class SimplePortals {
+
+    public SimplePortals(BMEssentials plugin) {
+        WildData wildData = new WildData(plugin);
+        WildCommand wildCommand = new WildCommand(wildData, plugin);
+        HealCommand healCommand = new HealCommand(plugin);
+
+        SessionManager manager = WorldGuard.getInstance().getPlatform().getSessionManager();
+        manager.registerHandler(new SendToWildHandler.Factory(wildCommand), null);
+        manager.registerHandler(new HealingSpringsHandler.Factory(healCommand), null);
+    }
+
+    private static class SendToWildHandler extends FlagValueChangeHandler<StateFlag.State> {
+        private final WildCommand wild;
+
+        protected SendToWildHandler(Session session, WildCommand wild) {
+            super(session, BMEssentials.SEND_TO_WILD_FLAG);
+            this.wild = wild;
+        }
+
+        @Override
+        protected void onInitialValue(LocalPlayer player, ApplicableRegionSet set, StateFlag.State value) {
+        }
+
+        @Override
+        protected boolean onSetValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                     StateFlag.State currentValue, StateFlag.State lastValue, MoveType moveType) {
+            if (currentValue == StateFlag.State.ALLOW && currentValue != lastValue) {
+                Player bukkitPlayer = BukkitAdapter.adapt(player);
+                wild.randomLocation(bukkitPlayer, "all");
+            }
+            return true;
+        }
+
+        @Override
+        protected boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                        StateFlag.State lastValue, MoveType moveType) {
+            return true;
+        }
+
+        public static class Factory extends Handler.Factory<SendToWildHandler> {
+            private final WildCommand wild;
+            public Factory(WildCommand wild) {
+                this.wild = wild;
+            }
+            @Override
+            public SendToWildHandler create(Session session) {
+                return new SendToWildHandler(session, wild);
+            }
+        }
+    }
+
+    private static class HealingSpringsHandler extends FlagValueChangeHandler<StateFlag.State> {
+        private final HealCommand heal;
+
+        protected HealingSpringsHandler(Session session, HealCommand heal) {
+            super(session, BMEssentials.ENTERED_HEALING_SPRINGS_FLAG);
+            this.heal = heal;
+        }
+
+        @Override
+        protected void onInitialValue(LocalPlayer player, ApplicableRegionSet set, StateFlag.State value) {
+        }
+
+        @Override
+        protected boolean onSetValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                     StateFlag.State currentValue, StateFlag.State lastValue, MoveType moveType) {
+            if (currentValue == StateFlag.State.ALLOW && currentValue != lastValue) {
+                Player p = BukkitAdapter.adapt(player);
+                heal.checkAndExecute(p);
+            }
+            return true;
+        }
+
+        @Override
+        protected boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet set,
+                                        StateFlag.State lastValue, MoveType moveType) {
+            return true;
+        }
+
+        public static class Factory extends Handler.Factory<HealingSpringsHandler> {
+            private final HealCommand heal;
+            public Factory(HealCommand heal) {
+                this.heal = heal;
+            }
+            @Override
+            public HealingSpringsHandler create(Session session) {
+                return new HealingSpringsHandler(session, heal);
+            }
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/SpawnSystems/HealCommand.java
@@ -5,9 +5,6 @@ import at.sleazlee.bmessentials.Scheduler;
 import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandExecutor;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -15,7 +12,7 @@ import org.bukkit.potion.PotionEffectType;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class HealCommand implements CommandExecutor {
+public class HealCommand {
 
 	private final BMEssentials plugin;
 
@@ -33,25 +30,7 @@ public class HealCommand implements CommandExecutor {
 		this.plugin = plugin;
 	}
 
-	@Override
-	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-		// Ensure the command is executed with at least one argument
-		if (args.length > 0) {
-			String playerName = args[0];
-			Player player = Bukkit.getPlayer(playerName);
-
-			if (player != null && sender.hasPermission("bmessentials.heal")) {
-				checkAndExecute(player);
-			} else {
-				sender.sendMessage("§cPlayer not found, not online, or you lack permissions.");
-			}
-		} else {
-			sender.sendMessage("§cUsage: /" + label + " <player>");
-		}
-		return true;
-	}
-
-	private void checkAndExecute(Player player) {
+        public void checkAndExecute(Player player) {
 		UUID playerUUID = player.getUniqueId();
 		long currentTime = System.currentTimeMillis();
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -107,6 +107,10 @@ Systems:
       #   Name: <Region Name>
       #   Return: <Return Value>
 
+  # Enables the SimplePortals system.
+  SimplePortals:
+    Enabled: true
+
   # Enables spawn only systems.
   SpawnSystems:
     Enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -111,9 +111,6 @@ commands:
     description: Toggle your BlueMap visibility
     usage: /maps <toggle|show|hide>
 
-  springsheal:
-    description: Heals the player.
-    usage: /springsheal
 
 
   playtime:


### PR DESCRIPTION
## Summary
- introduce `SimplePortals` system using WorldGuard custom flags
- register `send-to-wild` and `entered-healing-springs` flags
- call Wild teleport and Healing Springs logic when entering flagged regions
- remove `/springsheal` command
- expose HealingSprings functionality via method only
- update config and plugin metadata

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684e0bc955c08332bcccc92625d69229