### PR TITLE
Improve shop sign updating and add rental flag

### DIFF
--- a/src/main/resources/shops.yml
+++ b/src/main/resources/shops.yml
@@ -5,5 +5,6 @@
   extendTime: 604800000
   maxExtendTime: 31536000000
   Owner: ''
+  Rented: false
   CoOwner: ''
   Expires: 0


### PR DESCRIPTION
## Summary
- add `Rented` flag to shops.yml and `Shop` class
- adjust load/save logic and command handlers for new flag
- improve sign updates to respect facing and show remaining time more flexibly

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519a8824e48332bb85149e49151d44