### PR TITLE
Fix shop nickname defaults and add color features

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -279,4 +279,10 @@ Systems:
       admin-disband-usage: '<red>/bms admin disband <region> [confirm]</red>'
       admin-disband-confirm: '<red>Type /bms admin disband {region} confirm to disband.</red>'
       admin-disbanded: '<green>Region {region} disbanded.</green>'
+      name-usage: '<red>Usage: /bms name <color|hex> <value></red>'
+      color-changed: '<green>Shop name color updated.</green>'
+      color-no-permission: '<red>You do not have permission to color your shop name.</red>'
+      hex-no-permission: '<red>You do not have permission to use hex colors.</red>'
+      invalid-color: '<red>Invalid color.</red>'
+      invalid-hex: '<red>Invalid hex color.</red>'
 

--- a/src/main/resources/shops.yml
+++ b/src/main/resources/shops.yml
@@ -1,6 +1,7 @@
 '001':
   Rented: false
   Nickname: ''
+  NameColor: "§b"
   Price: 100.0
   Sign: world;251.0;71.0;128.0;NORTH
   extendTime: 604800000


### PR DESCRIPTION
## Summary
- allow custom shop name colors
- stop auto assigning nickname when a shop is bought or transferred
- color code lines on shop signs
- add `/bms name` commands and config messages
- store shop name color in `shops.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bae635c88332a0ac998fac9b617d