### PR TITLE
Add dynamic TPShop suggestions

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/Shops/TPShopCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/Shops/TPShopCommand.java
@@ -1,42 +1,53 @@
 package at.sleazlee.bmessentials.Shops;
 
+import at.sleazlee.bmessentials.BMEssentials;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.io.File;
 
 public class TPShopCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (sender instanceof Player) {
-            Player player = (Player) sender;
+        if (!(sender instanceof Player player)) {
+            return false;
+        }
 
-            // Creates a set for 001 to 092.
-            Set<String> validArgs = new HashSet<>();
-            for (int i = 1; i <= 92; i++) {
-                validArgs.add(String.format("%03d", i));
-            }
-
-            // Then, in your command execution logic
-            if (args.length > 0) {
-                String shopPlot = args[0];
-                if (validArgs.contains(shopPlot)) {
-                    // Your logic here
-                    Bukkit.getServer().dispatchCommand(player, "warp " + shopPlot);
-                } else {
-                    // Handle invalid case
-                    player.sendMessage("§b§lBMS§7 You need the shops plot number! Try §b/tpshop §8<§b###§8>§7.");
-                }
-            }
-
+        if (args.length == 0) {
+            player.sendMessage("§b§lBMS§7 You need the shops plot number! Try §b/tpshop §8<§b###§8>§7.");
             return true;
         }
 
-        return false;
+        String query = String.join(" ", args).trim();
+
+        File file = new File(BMEssentials.getInstance().getDataFolder(), "shops.yml");
+        FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+
+        String matchId = null;
+        for (String key : config.getKeys(false)) {
+            if (key.equalsIgnoreCase(query)) {
+                matchId = key;
+                break;
+            }
+            String nickname = config.getString(key + ".Nickname", "");
+            if (!nickname.isEmpty() && nickname.equalsIgnoreCase(query)) {
+                matchId = key;
+                break;
+            }
+        }
+
+        if (matchId != null) {
+            Bukkit.getServer().dispatchCommand(player, "warp " + matchId);
+        } else {
+            player.sendMessage("§b§lBMS§7 You need the shops plot number! Try §b/tpshop §8<§b###§8>§7.");
+        }
+
+        return true;
     }
 }

--- a/src/main/java/at/sleazlee/bmessentials/Shops/TPShopTabCompleter.java
+++ b/src/main/java/at/sleazlee/bmessentials/Shops/TPShopTabCompleter.java
@@ -1,113 +1,48 @@
 package at.sleazlee.bmessentials.Shops;
 
+import at.sleazlee.bmessentials.BMEssentials;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class TPShopTabCompleter implements TabCompleter {
-
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-        if (args.length == 1) {
-            List<String> list = new ArrayList<>();
-            list.add("001");
-            list.add("002");
-            list.add("003");
-            list.add("004");
-            list.add("005");
-            list.add("006");
-            list.add("007");
-            list.add("008");
-            list.add("009");
-            list.add("010");
-            list.add("011");
-            list.add("012");
-            list.add("013");
-            list.add("014");
-            list.add("015");
-            list.add("016");
-            list.add("017");
-            list.add("018");
-            list.add("019");
-            list.add("020");
-            list.add("021");
-            list.add("022");
-            list.add("023");
-            list.add("024");
-            list.add("025");
-            list.add("026");
-            list.add("027");
-            list.add("028");
-            list.add("029");
-            list.add("030");
-            list.add("031");
-            list.add("032");
-            list.add("033");
-            list.add("034");
-            list.add("035");
-            list.add("036");
-            list.add("037");
-            list.add("038");
-            list.add("039");
-            list.add("040");
-            list.add("041");
-            list.add("042");
-            list.add("043");
-            list.add("044");
-            list.add("045");
-            list.add("046");
-            list.add("047");
-            list.add("048");
-            list.add("049");
-            list.add("050");
-            list.add("051");
-            list.add("052");
-            list.add("053");
-            list.add("054");
-            list.add("055");
-            list.add("056");
-            list.add("057");
-            list.add("058");
-            list.add("059");
-            list.add("060");
-            list.add("061");
-            list.add("062");
-            list.add("063");
-            list.add("064");
-            list.add("065");
-            list.add("066");
-            list.add("067");
-            list.add("068");
-            list.add("069");
-            list.add("070");
-            list.add("071");
-            list.add("072");
-            list.add("073");
-            list.add("074");
-            list.add("075");
-            list.add("076");
-            list.add("077");
-            list.add("078");
-            list.add("079");
-            list.add("080");
-            list.add("081");
-            list.add("082");
-            list.add("083");
-            list.add("084");
-            list.add("085");
-            list.add("086");
-            list.add("087");
-            list.add("088");
-            list.add("089");
-            list.add("090");
-            list.add("091");
-            list.add("092");
-            return list;
-        }
+        if (args.length >= 1) {
+            String prefix = String.join(" ", args).toLowerCase();
+            File file = new File(BMEssentials.getInstance().getDataFolder(), "shops.yml");
+            FileConfiguration config = YamlConfiguration.loadConfiguration(file);
 
-        return null;
+            List<String> nicknames = new ArrayList<>();
+            List<String> ids = new ArrayList<>();
+            for (String key : config.getKeys(false)) {
+                String nickname = config.getString(key + ".Nickname", "");
+                if (nickname != null && !nickname.isEmpty()) {
+                    nicknames.add(nickname);
+                }
+                ids.add(key);
+            }
+
+            List<String> result = new ArrayList<>();
+            for (String name : nicknames) {
+                if (name.toLowerCase().startsWith(prefix)) {
+                    result.add(name);
+                }
+            }
+            for (String id : ids) {
+                if (id.toLowerCase().startsWith(prefix)) {
+                    result.add(id);
+                }
+            }
+            return result;
+        }
+        return Collections.emptyList();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,7 +17,7 @@ commands:
 
   tpshop:
     description: Sends the player to a shop of their choosing.
-    usage: /tpshop <###>
+    usage: /tpshop <shop>
 
   wild:
     description: Teleport to a random location.


### PR DESCRIPTION
## Summary
- look up shop IDs and nicknames from shops.yml for `/tpshop`
- tab completion shows nicknames first then IDs
- `/tpshop` accepts shop nicknames with spaces
- update plugin docs

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f6fdf2388332bf731683d514731b