### PR TITLE
Fix partial shop rent pricing

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/Shops/Shops.java
+++ b/src/main/java/at/sleazlee/bmessentials/Shops/Shops.java
@@ -695,15 +695,24 @@ public class Shops implements CommandExecutor, TabCompleter, Listener {
         }
         long now = System.currentTimeMillis();
         long remaining = Math.max(0, shop.expires - now);
-        if (remaining + shop.extendTime > shop.maxExtendTime) {
+
+        long maxAdditional = shop.maxExtendTime - remaining;
+        if (maxAdditional <= 0) {
             send(player, "beyond-max");
             return true;
         }
-        if (!withdraw(player, shop.price)) {
+
+        long added = Math.min(shop.extendTime, maxAdditional);
+        double fraction = (double) added / (double) shop.extendTime;
+        double cost = shop.price * fraction;
+        cost = Math.round(cost * 100.0) / 100.0;
+
+        if (!withdraw(player, cost)) {
             send(player, "cannot-afford-rent");
             return true;
         }
-        shop.expires = now + remaining + shop.extendTime;
+
+        shop.expires = now + remaining + added;
         saveShops();
         updateSign(shop);
         send(player, "rent-extended");


### PR DESCRIPTION
## Summary
- when shop rent time extension caps at max time, charge proportionally to added time

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559745dc788332881d98e1fc48a60d