### PR TITLE
Add CombineSystem for unsafe enchantments

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -58,6 +58,7 @@ import at.sleazlee.bmessentials.wild.*;
 import at.sleazlee.bmessentials.playerutils.InvseeCommand;
 import at.sleazlee.bmessentials.playerutils.InvseeTabCompleter;
 import at.sleazlee.bmessentials.playerutils.SeenCommand;
+import at.sleazlee.bmessentials.CombineSystem.CombineListener;
 import com.sk89q.worldguard.protection.flags.StringFlag;
 import lombok.Getter;
 import org.bukkit.Bukkit;
@@ -373,6 +374,12 @@ public class BMEssentials extends JavaPlugin {
 
             // Anvil
             this.getCommand("anvil").setExecutor(new AnvilCommand());
+        }
+
+        // Combine System
+        if (config.getBoolean("Systems.CombineSystem.Enabled")) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled Combine System");
+            getServer().getPluginManager().registerEvents(new CombineListener(), this);
         }
 
         // Inventory tools

--- a/src/main/java/at/sleazlee/bmessentials/CombineSystem/CombineListener.java
+++ b/src/main/java/at/sleazlee/bmessentials/CombineSystem/CombineListener.java
@@ -1,0 +1,56 @@
+package at.sleazlee.bmessentials.CombineSystem;
+
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.inventory.AnvilInventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+
+import java.util.Map;
+
+/**
+ * Allows players to apply unsafe enchantment levels using anvils
+ * while preventing the creation of new unsafe books.
+ */
+public class CombineListener implements Listener {
+
+    @EventHandler
+    public void onPrepareAnvil(PrepareAnvilEvent event) {
+        AnvilInventory inventory = event.getInventory();
+        ItemStack left = inventory.getItem(0);
+        ItemStack right = inventory.getItem(1);
+
+        if (left == null || right == null) {
+            return;
+        }
+
+        boolean leftBook = left.getType() == Material.ENCHANTED_BOOK;
+        boolean rightBook = right.getType() == Material.ENCHANTED_BOOK;
+
+        // Prevent combining two books to create unsafe levels
+        if (leftBook && rightBook) {
+            event.setResult(null);
+            return;
+        }
+
+        if (!(leftBook ^ rightBook)) {
+            return; // only process when exactly one item is a book
+        }
+
+        ItemStack item = leftBook ? right : left;
+        ItemStack book = leftBook ? left : right;
+        if (!(book.getItemMeta() instanceof EnchantmentStorageMeta meta)) {
+            return;
+        }
+
+        ItemStack result = item.clone();
+        for (Map.Entry<Enchantment, Integer> entry : meta.getStoredEnchants().entrySet()) {
+            result.addUnsafeEnchantment(entry.getKey(), entry.getValue());
+        }
+
+        event.setResult(result);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -166,6 +166,10 @@ Systems:
   Containers:
     Enabled: true
 
+  # Allows applying unsafe enchantment books to items using anvils.
+  CombineSystem:
+    Enabled: true
+
   # Enables the Velocity Tell system.
   VTell:
     Enabled: true


### PR DESCRIPTION
## Summary
- add CombineSystem that lets anvils apply unsafe books but blocks book combination
- hook CombineSystem in plugin startup when enabled
- add `CombineSystem` section to config.yml

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855e8b467148332894e480c6fe942a9