### PR TITLE
Allow generating wild locations per-version

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -94,6 +94,9 @@ public class BMEssentials extends JavaPlugin {
     /** The database for the trophy system. */
     private TrophyDatabase trophiesDB;
 
+    /** Database storing pregenerated wild locations. */
+    private WildLocationsDatabase wildDB;
+
     /** The database for the PlayerData system.
      * -- GETTER --
      *  Gets the instance of the DatabaseManager.
@@ -294,12 +297,13 @@ public class BMEssentials extends JavaPlugin {
 
             // Create an instance of WildData with the plugin instance
             WildData wildData = new WildData(this);
+            wildDB = new WildLocationsDatabase(this, wildData);
 
             // Register the NoFallDamage event listener.
             getServer().getPluginManager().registerEvents(new NoFallDamage(), this);
 
             // Instantiate the command executor and tab completer, passing the WildData instance.
-            WildCommand wildCommand = new WildCommand(wildData, this);
+            WildCommand wildCommand = new WildCommand(wildData, wildDB, this);
             WildTabCompleter wildTabCompleter = new WildTabCompleter(wildData);
 
             // Register the /wild command executor and tab completer.
@@ -313,7 +317,7 @@ public class BMEssentials extends JavaPlugin {
         // SimplePortals system using WorldGuard regions
         if (config.getBoolean("Systems.SimplePortals.Enabled")) {
             getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled SimplePortals");
-            new SimplePortals(this);
+            new SimplePortals(this, wildDB);
         }
 
         // Spawn Systems
@@ -628,6 +632,10 @@ public class BMEssentials extends JavaPlugin {
         // Close the PlayerData Database Connection
         if (PlayerDataDBManager != null) {
             PlayerDataDBManager.closeConnection();
+        }
+
+        if (wildDB != null) {
+            wildDB.close();
         }
 
         // Log a message to indicate the plugin has been successfully disabled

--- a/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
+++ b/src/main/java/at/sleazlee/bmessentials/SimplePortals/SimplePortals.java
@@ -4,6 +4,7 @@ import at.sleazlee.bmessentials.BMEssentials;
 import at.sleazlee.bmessentials.SpawnSystems.HealCommand;
 import at.sleazlee.bmessentials.wild.WildCommand;
 import at.sleazlee.bmessentials.wild.WildData;
+import at.sleazlee.bmessentials.wild.WildLocationsDatabase;
 import at.sleazlee.bmessentials.huskhomes.HuskHomesAPIHook;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.util.Location;
@@ -23,9 +24,9 @@ import org.bukkit.entity.Player;
  */
 public class SimplePortals {
 
-    public SimplePortals(BMEssentials plugin) {
+    public SimplePortals(BMEssentials plugin, WildLocationsDatabase wildDB) {
         WildData wildData = new WildData(plugin);
-        WildCommand wildCommand = new WildCommand(wildData, plugin);
+        WildCommand wildCommand = new WildCommand(wildData, wildDB, plugin);
         HealCommand healCommand = new HealCommand(plugin);
 
         SessionManager manager = WorldGuard.getInstance().getPlatform().getSessionManager();

--- a/src/main/java/at/sleazlee/bmessentials/wild/WildCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/wild/WildCommand.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
 public class WildCommand implements CommandExecutor {
 
     private final WildData wildData; // Holds info about each version's Lower/Upper ring
+    private final WildLocationsDatabase database; // Storage for pregenerated locations
     private final Logger logger;     // For logging
     private final JavaPlugin plugin; // Reference to main plugin for scheduling tasks
 
@@ -46,15 +47,66 @@ public class WildCommand implements CommandExecutor {
      * @param wildData the WildData that contains version bounds.
      * @param plugin   the main plugin instance (for logging, scheduling, etc.).
      */
-    public WildCommand(WildData wildData, JavaPlugin plugin) {
+    public WildCommand(WildData wildData, WildLocationsDatabase database, JavaPlugin plugin) {
         this.wildData = wildData;
+        this.database = database;
         this.logger = plugin.getLogger();
         this.plugin = plugin;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        // Ensure sender is a Player
+        // Admin subcommands
+        if (args.length >= 2 && args[0].equalsIgnoreCase("admin")) {
+            if (!sender.hasPermission("bmessentials.wild.admin")) {
+                sender.sendMessage("§c§lWild §cYou do not have permission to use this command.");
+                return true;
+            }
+
+            if (!(sender instanceof org.bukkit.command.ConsoleCommandSender)) {
+                sender.sendMessage("§c§lWild §cThis command can only be run from the console.");
+                return true;
+            }
+
+            if (args.length >= 2) {
+                String sub = args[1].toLowerCase();
+                switch (sub) {
+                    case "gen":
+                        if (args.length >= 3) {
+                            String bound = args[2];
+                            generateLocations(sender, bound);
+                        } else {
+                            generateAllLocations(sender);
+                        }
+                        break;
+                    case "clear":
+                        if (args.length >= 3) {
+                            String bound = args[2];
+                            database.purgeLocations(bound);
+                            sender.sendMessage("§aCleared locations for " + bound);
+                        } else {
+                            sender.sendMessage("§c§lWild §cUsage: /wild admin clear <bound>");
+                        }
+                        break;
+                    case "count":
+                        if (args.length >= 3) {
+                            String bound = args[2];
+                            int count = database.getLocationCount(bound);
+                            sender.sendMessage("§a" + count + " stored locations for " + bound);
+                        } else {
+                            sender.sendMessage("§c§lWild §cUsage: /wild admin count <bound>");
+                        }
+                        break;
+                    default:
+                        sender.sendMessage("§c§lWild §cUsage: /wild admin <gen|clear|count> [bound]");
+                        break;
+                }
+            } else {
+                sender.sendMessage("§c§lWild §cUsage: /wild admin <gen|clear|count> [bound]");
+            }
+            return true;
+        }
+
         if (!(sender instanceof Player)) {
             sender.sendMessage("§c§lWild §cThis command can only be used by a player.");
             return true;
@@ -66,13 +118,13 @@ public class WildCommand implements CommandExecutor {
         // /wild 1.21 => specifically that version
         // /wild all => random version
         if (args.length == 0) {
-            randomLocation(player, "all");
+            teleportFromDatabase(player, "all");
         } else if (args.length == 1) {
             String version = args[0];
             if (wildData.getVersions().contains(version)) {
-                randomLocation(player, version);
+                teleportFromDatabase(player, version);
             } else if ("all".equalsIgnoreCase(version)) {
-                randomLocation(player, "all");
+                teleportFromDatabase(player, "all");
             } else {
                 player.sendMessage("§c§lWild §cInvalid version. Try /wild [version or all]");
             }
@@ -94,6 +146,47 @@ public class WildCommand implements CommandExecutor {
      *
      * @param player  the player to teleport
      * @param version a specific version or "all" to choose randomly from config
+     */
+    /**
+     * Teleport the player using a pregenerated location from the database.
+     */
+    public void teleportFromDatabase(Player player, String version) {
+        Random random = new Random();
+
+        String chosenVersion = version;
+        if ("all".equalsIgnoreCase(version)) {
+            Set<String> versionSet = wildData.getVersions();
+            if (versionSet.isEmpty()) {
+                player.sendMessage("§c§lWild §cNo versions defined in config.");
+                return;
+            }
+            List<String> versionsList = new ArrayList<>(versionSet);
+            chosenVersion = versionsList.get(random.nextInt(versionsList.size()));
+        }
+
+        database.getAndRotateLocationAsync(chosenVersion, coords -> {
+            if (coords == null) {
+                player.sendMessage("§c§lWild §cNo pregenerated locations for that bound.");
+                return;
+            }
+
+            double finalX = coords[0];
+            double finalZ = coords[1];
+            double finalY = 345;
+
+            String worldName = "world";
+            String serverName = "blockminer";
+
+            if (IsInWorldGuardRegion.isPlayerInRegion(player, "Spawn")) {
+                HuskHomesAPIHook.instantTeleportPlayer(player, finalX, finalY, finalZ, 0, 90, worldName, serverName);
+            } else {
+                HuskHomesAPIHook.timedTeleportPlayer(player, finalX, finalY, finalZ, 0, 90, worldName, serverName);
+            }
+        });
+    }
+
+    /**
+     * Legacy random teleport used for generating locations.
      */
     public void randomLocation(Player player, String version) {
         // 1) Choose the version’s bounds
@@ -200,6 +293,73 @@ public class WildCommand implements CommandExecutor {
         } else {
             // Timed teleport otherwise
             HuskHomesAPIHook.timedTeleportPlayer(player, finalX, finalY, finalZ, 0, 90, worldName, serverName);
+        }
+    }
+
+    /**
+     * Generates and stores random locations for the specified bound until 5000 entries exist.
+     */
+    private void generateLocations(CommandSender sender, String bound) {
+        WildData.CoordinateBounds bounds = wildData.getBounds(bound);
+        if (bounds == null) {
+            sender.sendMessage("§c§lWild §cUnknown bound " + bound);
+            return;
+        }
+
+        int current = database.getLocationCount(bound);
+        int target = 5000;
+        int toGenerate = target - current;
+        if (toGenerate <= 0) {
+            sender.sendMessage("§aAlready have " + current + " locations for " + bound);
+            return;
+        }
+
+        double lower = bounds.getLower();
+        double upper = bounds.getUpper();
+        double centerX = wildData.getCenterX();
+        double centerZ = wildData.getCenterZ();
+        double finalY = 345;
+        Random random = new Random();
+        int generated = 0;
+
+        while (generated < toGenerate) {
+            double xOffset = random.nextDouble() * (2 * upper) - upper;
+            double zOffset = random.nextDouble() * (2 * upper) - upper;
+            double chebDist = Math.max(Math.abs(xOffset), Math.abs(zOffset));
+            if (chebDist < lower || chebDist > upper) {
+                continue;
+            }
+
+            int finalX = (int) Math.round(centerX + xOffset);
+            int finalZ = (int) Math.round(centerZ + zOffset);
+
+            boolean isWater = false;
+            for (int y = 0; y < finalY; y++) {
+                Material type = new Location(plugin.getServer().getWorld("world"), finalX, y, finalZ).getBlock().getType();
+                if (type == Material.WATER) {
+                    isWater = true;
+                    break;
+                }
+            }
+
+            if (!isWater) {
+                database.insertLocation(bound, finalX, finalZ);
+                sender.sendMessage("§aAdded location: X=" + finalX + " Z=" + finalZ);
+                generated++;
+            }
+        }
+
+        int total = database.getLocationCount(bound);
+        sender.sendMessage("§aGenerated " + generated + " locations for " + bound + ". Total: " + total);
+        sender.sendMessage("§aGeneration complete.");
+    }
+
+    /**
+     * Generate locations for all configured bounds.
+     */
+    private void generateAllLocations(CommandSender sender) {
+        for (String ver : wildData.getVersions()) {
+            generateLocations(sender, ver);
         }
     }
 

--- a/src/main/java/at/sleazlee/bmessentials/wild/WildLocationsDatabase.java
+++ b/src/main/java/at/sleazlee/bmessentials/wild/WildLocationsDatabase.java
@@ -1,0 +1,207 @@
+package at.sleazlee.bmessentials.wild;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.*;
+import java.util.Set;
+import java.util.function.Consumer;
+import at.sleazlee.bmessentials.Scheduler;
+import java.util.logging.Logger;
+
+/**
+ * Handles storage of pre-generated wild teleport locations using SQLite.
+ */
+public class WildLocationsDatabase {
+
+    private final JavaPlugin plugin;
+    private final Logger logger;
+    private Connection connection;
+
+    public WildLocationsDatabase(JavaPlugin plugin, WildData wildData) {
+        this.plugin = plugin;
+        this.logger = plugin.getLogger();
+        connect();
+        createTables(wildData.getVersions());
+    }
+
+    private void connect() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                return;
+            }
+            if (!plugin.getDataFolder().exists() && !plugin.getDataFolder().mkdirs()) {
+                logger.severe("Could not create plugin data folder for database");
+            }
+            File dbFile = new File(plugin.getDataFolder(), "WildLocations.db");
+            connection = DriverManager.getConnection("jdbc:sqlite:" + dbFile);
+        } catch (SQLException e) {
+            logger.severe("Could not connect to WildLocations database: " + e.getMessage());
+        }
+    }
+
+    private void createTables(Set<String> versions) {
+        for (String version : versions) {
+            createTable(version);
+        }
+    }
+
+    private void createTable(String version) {
+        String table = sanitize(version);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE IF NOT EXISTS " + table + " (" +
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                    "x INTEGER," +
+                    "z INTEGER" +
+                    ")");
+        } catch (SQLException e) {
+            logger.severe("Error creating table " + table + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Sanitize a bound/version name for use as a SQLite table. All characters
+     * other than letters, numbers and underscore are replaced with an
+     * underscore. If the resulting name does not begin with a letter or
+     * underscore, a 'v' prefix is added to produce a valid identifier.
+     */
+    private String sanitize(String version) {
+        String table = version.replaceAll("[^a-zA-Z0-9_]", "_");
+        if (!table.matches("^[A-Za-z_].*")) {
+            table = "v" + table;
+        }
+        return table;
+    }
+
+    public void insertLocation(String version, int x, int z) {
+        createTable(version);
+        String table = sanitize(version);
+        String sql = "INSERT INTO " + table + " (x, z) VALUES (?, ?)";
+        try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setInt(1, x);
+            pstmt.setInt(2, z);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            logger.severe("Error inserting location into " + table + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Asynchronously insert a new location.
+     */
+    public void insertLocationAsync(String version, int x, int z) {
+        Scheduler.runAsync(() -> insertLocation(version, x, z));
+    }
+
+    public int[] getAndRotateLocation(String version) {
+        createTable(version);
+        String table = sanitize(version);
+        String select = "SELECT id,x,z FROM " + table + " ORDER BY id ASC LIMIT 1";
+        try (PreparedStatement stmt = connection.prepareStatement(select)) {
+            ResultSet rs = stmt.executeQuery();
+            if (!rs.next()) {
+                return null;
+            }
+            int id = rs.getInt("id");
+            int x = rs.getInt("x");
+            int z = rs.getInt("z");
+            rs.close();
+
+            connection.setAutoCommit(false);
+            try {
+                try (PreparedStatement del = connection.prepareStatement("DELETE FROM " + table + " WHERE id = ?")) {
+                    del.setInt(1, id);
+                    del.executeUpdate();
+                }
+                try (PreparedStatement ins = connection.prepareStatement("INSERT INTO " + table + " (x,z) VALUES (?,?)")) {
+                    ins.setInt(1, x);
+                    ins.setInt(2, z);
+                    ins.executeUpdate();
+                }
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+            return new int[]{x, z};
+        } catch (SQLException e) {
+            logger.severe("Error rotating location in " + table + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Retrieve and rotate a location asynchronously.
+     * The callback is executed on the main server thread.
+     *
+     * @param version  the bound/version name
+     * @param callback consumer receiving the x/z coordinate pair or null
+     */
+    public void getAndRotateLocationAsync(String version, Consumer<int[]> callback) {
+        Scheduler.runAsync(() -> {
+            int[] coords = getAndRotateLocation(version);
+            Scheduler.run(() -> callback.accept(coords));
+        });
+    }
+
+    public int getLocationCount(String version) {
+        String table = sanitize(version);
+        try (Statement stmt = connection.createStatement()) {
+            ResultSet rs = stmt.executeQuery("SELECT COUNT(*) AS cnt FROM " + table);
+            int count = rs.getInt("cnt");
+            rs.close();
+            return count;
+        } catch (SQLException e) {
+            logger.severe("Error counting locations for " + table + ": " + e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * Asynchronously count locations.
+     */
+    public void getLocationCountAsync(String version, Consumer<Integer> callback) {
+        Scheduler.runAsync(() -> {
+            int count = getLocationCount(version);
+            Scheduler.run(() -> callback.accept(count));
+        });
+    }
+
+    /**
+     * Remove all stored locations for the specified version.
+     *
+     * @param version the bound/version name
+     */
+    public void purgeLocations(String version) {
+        String table = sanitize(version);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate("DELETE FROM " + table);
+        } catch (SQLException e) {
+            logger.severe("Error purging locations for " + table + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Purge all locations for a version asynchronously.
+     */
+    public void purgeLocationsAsync(String version, Runnable callback) {
+        Scheduler.runAsync(() -> {
+            purgeLocations(version);
+            if (callback != null) {
+                Scheduler.run(callback);
+            }
+        });
+    }
+
+    public void close() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            logger.severe("Error closing WildLocations database: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,8 +20,8 @@ commands:
     usage: /tpshop <shop>
 
   wild:
-    description: Teleport to a random location.
-    usage: /wild [version]
+    description: Teleport to a random location or manage pregenerated spots.
+    usage: /wild [version|admin]
     aliases:
     - rtp
     - randomtp
@@ -275,3 +275,7 @@ permissions:
   bmessentials.shops.hex:
     description: Allows the player chose any Hex color for their shops name on the shops sign.
     default: false
+
+  bmessentials.wild.admin:
+    description: Allows use of /wild admin commands.
+    default: op


### PR DESCRIPTION
## Summary
- add ability for `/wild admin gen` to run for all versions or a single bound
- mention admin usage in `plugin.yml`
- pass the `WildLocationsDatabase` to `SimplePortals`
- prefix generated SQLite table names so versions like `1.19` don't break table creation

## Testing
- `mvn -q -DskipTests install` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597906f32c8332a2980fbd562d2035