### PR TITLE
Add WorldGuard walk speed flag

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -43,6 +43,7 @@ import at.sleazlee.bmessentials.art.Art;
 import at.sleazlee.bmessentials.bmefunctions.BMECommandExecutor;
 import at.sleazlee.bmessentials.bmefunctions.BMRestart;
 import at.sleazlee.bmessentials.bmefunctions.CommonCommands;
+import at.sleazlee.bmessentials.bmefunctions.WalkSpeedSystem;
 import at.sleazlee.bmessentials.crypto.AESEncryptor;
 import at.sleazlee.bmessentials.huskhomes.LandsTeleportFixListener;
 import at.sleazlee.bmessentials.rankup.RankUpManager;
@@ -70,6 +71,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.DoubleFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 
@@ -127,6 +129,9 @@ public class BMEssentials extends JavaPlugin {
     /** Custom WorldGuard flag for sending players to a named warp */
     public static StringFlag SEND_TO_WARP_FLAG;
 
+    /** Custom WorldGuard flag for setting player walk speed */
+    public static DoubleFlag SET_WALK_SPEED_FLAG;
+
     /**
      * Gets the instance of the main plugin class.
      *
@@ -172,6 +177,17 @@ public class BMEssentials extends JavaPlugin {
                 SEND_TO_WARP_FLAG = stringFlag;
             }
         }
+
+        try {
+            DoubleFlag flag = new DoubleFlag("bm-set-walk-speed");
+            registry.register(flag);
+            SET_WALK_SPEED_FLAG = flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get("bm-set-walk-speed");
+            if (existing instanceof DoubleFlag doubleFlag) {
+                SET_WALK_SPEED_FLAG = doubleFlag;
+            }
+        }
     }
 
     /**
@@ -208,6 +224,9 @@ public class BMEssentials extends JavaPlugin {
         for (String line : startArt) {
             getServer().getConsoleSender().sendMessage(ChatColor.AQUA + line);
         }
+
+        // Register the WorldGuard walk speed handler
+        new WalkSpeedSystem();
 
         // Enable PlayerData Systems
         if (getConfig().getBoolean("Systems.PlayerData.Enabled")) {

--- a/src/main/java/at/sleazlee/bmessentials/bmefunctions/AbstractSpeedFlagHandler.java
+++ b/src/main/java/at/sleazlee/bmessentials/bmefunctions/AbstractSpeedFlagHandler.java
@@ -1,0 +1,69 @@
+package at.sleazlee.bmessentials.bmefunctions;
+
+import com.sk89q.worldedit.bukkit.BukkitPlayer;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.DoubleFlag;
+import com.sk89q.worldguard.session.MoveType;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.handler.FlagValueChangeHandler;
+import org.bukkit.entity.Player;
+
+public abstract class AbstractSpeedFlagHandler extends FlagValueChangeHandler<Double> {
+    private Float originalSpeed;
+
+    protected AbstractSpeedFlagHandler(Session session, DoubleFlag flag) {
+        super(session, flag);
+    }
+
+    protected abstract float getSpeed(Player player);
+
+    protected abstract void setSpeed(Player player, float speed);
+
+    @Override
+    protected void onInitialValue(LocalPlayer player, ApplicableRegionSet set, Double value) {
+        this.handleValue(player, player.getWorld(), value);
+    }
+
+    @Override
+    protected boolean onSetValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet,
+                                 Double currentValue, Double lastValue, MoveType moveType) {
+        this.handleValue(player, (World) to.getExtent(), currentValue);
+        return true;
+    }
+
+    @Override
+    protected boolean onAbsentValue(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet,
+                                    Double lastValue, MoveType moveType) {
+        this.handleValue(player, (World) to.getExtent(), null);
+        return true;
+    }
+
+    private void handleValue(LocalPlayer player, World world, Double speed) {
+        Player bukkitPlayer = ((BukkitPlayer) player).getPlayer();
+
+        if (!this.getSession().getManager().hasBypass(player, world) && speed != null) {
+            if (speed > 1.0) {
+                speed = 1.0;
+            } else if (speed < -1.0) {
+                speed = -1.0;
+            }
+
+            if (this.getSpeed(bukkitPlayer) != speed.floatValue()) {
+                if (this.originalSpeed == null) {
+                    this.originalSpeed = this.getSpeed(bukkitPlayer);
+                }
+
+                this.setSpeed(bukkitPlayer, speed.floatValue());
+            }
+        } else {
+            if (this.originalSpeed != null) {
+                this.setSpeed(bukkitPlayer, this.originalSpeed);
+
+                this.originalSpeed = null;
+            }
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/bmefunctions/WalkSpeedFlagHandler.java
+++ b/src/main/java/at/sleazlee/bmessentials/bmefunctions/WalkSpeedFlagHandler.java
@@ -1,0 +1,33 @@
+package at.sleazlee.bmessentials.bmefunctions;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import com.sk89q.worldguard.session.Session;
+import com.sk89q.worldguard.session.handler.Handler;
+import org.bukkit.entity.Player;
+
+public class WalkSpeedFlagHandler extends AbstractSpeedFlagHandler {
+    public static Handler.Factory<WalkSpeedFlagHandler> FACTORY() {
+        return new Factory();
+    }
+
+    public static class Factory extends Handler.Factory<WalkSpeedFlagHandler> {
+        @Override
+        public WalkSpeedFlagHandler create(Session session) {
+            return new WalkSpeedFlagHandler(session);
+        }
+    }
+
+    protected WalkSpeedFlagHandler(Session session) {
+        super(session, BMEssentials.SET_WALK_SPEED_FLAG);
+    }
+
+    @Override
+    protected float getSpeed(Player player) {
+        return player.getWalkSpeed();
+    }
+
+    @Override
+    protected void setSpeed(Player player, float speed) {
+        player.setWalkSpeed(speed);
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/bmefunctions/WalkSpeedSystem.java
+++ b/src/main/java/at/sleazlee/bmessentials/bmefunctions/WalkSpeedSystem.java
@@ -1,0 +1,11 @@
+package at.sleazlee.bmessentials.bmefunctions;
+
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.session.SessionManager;
+
+public class WalkSpeedSystem {
+    public WalkSpeedSystem() {
+        SessionManager manager = WorldGuard.getInstance().getPlatform().getSessionManager();
+        manager.registerHandler(WalkSpeedFlagHandler.FACTORY(), null);
+    }
+}


### PR DESCRIPTION
## Summary
- add custom walk speed flag for regions
- register new flag and handler
- control walk speed within regions using WalkSpeedFlagHandler

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685da181e3e08332b9ad596103c51167