### PR TITLE
Add TreeFeller system

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -618,6 +618,12 @@ public class BMEssentials extends JavaPlugin {
             }
         }
 
+        // TreeFeller System
+        if (config.getBoolean("Systems.TreeFeller.Enabled")) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Enabled TreeFeller System");
+            new at.sleazlee.bmessentials.TreeFeller.TreeFellerManager(this);
+        }
+
         // Lands TP Fix System
         if (config.getBoolean("Systems.LandsTPFix.Enabled")) {
             getServer().getConsoleSender().sendMessage(ChatColor.WHITE + " - Fixed the Lands TP System");

--- a/src/main/java/at/sleazlee/bmessentials/TreeFeller/ToggleCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/TreeFeller/ToggleCommand.java
@@ -1,0 +1,30 @@
+package at.sleazlee.bmessentials.TreeFeller;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+/**
+ * Command used to toggle automatic tree felling for an individual player.
+ */
+public class ToggleCommand implements CommandExecutor {
+    private final TreeFellerManager manager;
+
+    public ToggleCommand(TreeFellerManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("Only players can toggle TreeFeller.");
+            return true;
+        }
+
+        manager.toggle(player);
+        boolean enabled = manager.isEnabled(player);
+        player.sendMessage("TreeFeller is now " + (enabled ? "enabled" : "disabled") + ".");
+        return true;
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/TreeFeller/TreeFellerListener.java
+++ b/src/main/java/at/sleazlee/bmessentials/TreeFeller/TreeFellerListener.java
@@ -1,0 +1,121 @@
+package at.sleazlee.bmessentials.TreeFeller;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+import java.lang.reflect.Method;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Listener that intercepts log breaking and delegates tree felling to mcMMO
+ * when appropriate.
+ */
+public class TreeFellerListener implements Listener {
+    private final TreeFellerManager manager;
+    private final Method getPlayerMethod;
+    private final Method getWoodcuttingManagerMethod;
+    private final Method processTreeFellerMethod;
+    private final Method getUserBlockTrackerMethod;
+    private final Method isIneligibleMethod;
+
+    private static final Set<Material> AXES = EnumSet.of(
+        Material.WOODEN_AXE, Material.STONE_AXE, Material.IRON_AXE,
+        Material.GOLDEN_AXE, Material.DIAMOND_AXE, Material.NETHERITE_AXE
+    );
+
+    public TreeFellerListener(TreeFellerManager manager) {
+        this.manager = manager;
+        Method getPlayer = null;
+        Method getManager = null;
+        Method process = null;
+        Method getTracker = null;
+        Method isIneligible = null;
+        try {
+            Class<?> userManager = Class.forName("com.gmail.nossr50.util.player.UserManager");
+            getPlayer = userManager.getMethod("getPlayer", Player.class);
+            Class<?> mcMMOPlayer = Class.forName("com.gmail.nossr50.datatypes.player.McMMOPlayer");
+            getManager = mcMMOPlayer.getMethod("getWoodcuttingManager");
+            Class<?> woodcuttingManager = Class.forName("com.gmail.nossr50.skills.woodcutting.WoodcuttingManager");
+            process = woodcuttingManager.getMethod("processTreeFeller", Block.class);
+            Class<?> mcMMOClass = Class.forName("com.gmail.nossr50.mcMMO");
+            getTracker = mcMMOClass.getMethod("getUserBlockTracker");
+            Class<?> trackerClass = Class.forName("com.gmail.nossr50.util.blockmeta.UserBlockTracker");
+            isIneligible = trackerClass.getMethod("isIneligible", Block.class);
+        } catch (ReflectiveOperationException e) {
+            manager.getPlugin().getLogger().warning("Failed to load mcMMO TreeFeller hooks: " + e.getMessage());
+        }
+        this.getPlayerMethod = getPlayer;
+        this.getWoodcuttingManagerMethod = getManager;
+        this.processTreeFellerMethod = process;
+        this.getUserBlockTrackerMethod = getTracker;
+        this.isIneligibleMethod = isIneligible;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockBreak(BlockBreakEvent event) {
+        Player player = event.getPlayer();
+        if (!manager.isEnabled(player)) {
+            return;
+        }
+        if (player.isSneaking()) {
+            return;
+        }
+
+        ItemStack hand = player.getInventory().getItemInMainHand();
+        if (hand == null || !AXES.contains(hand.getType())) {
+            return;
+        }
+
+        Block block = event.getBlock();
+        if (!isLog(block.getType())) {
+            return;
+        }
+
+        Plugin mcmmo = player.getServer().getPluginManager().getPlugin("mcMMO");
+        if (mcmmo == null || !mcmmo.isEnabled()) {
+            return;
+        }
+
+        if (invokeTreeFeller(player, block, event)) {
+            // tree feller handled the break
+        }
+    }
+
+    private static boolean isLog(Material mat) {
+        return mat.name().endsWith("_LOG") || mat.name().endsWith("_STEM");
+    }
+
+    /**
+     * Uses reflection to invoke mcMMO's tree feller logic on the given block.
+     */
+    private boolean invokeTreeFeller(Player player, Block block, BlockBreakEvent event) {
+        if (getPlayerMethod == null || getWoodcuttingManagerMethod == null || processTreeFellerMethod == null
+                || getUserBlockTrackerMethod == null || isIneligibleMethod == null) {
+            return false;
+        }
+        try {
+            Object tracker = getUserBlockTrackerMethod.invoke(null);
+            boolean placed = (Boolean) isIneligibleMethod.invoke(tracker, block);
+            if (placed) {
+                return false;
+            }
+
+            Object mcMMOPlayer = getPlayerMethod.invoke(null, player);
+            Object woodcuttingManager = getWoodcuttingManagerMethod.invoke(mcMMOPlayer);
+            processTreeFellerMethod.invoke(woodcuttingManager, block);
+            event.setCancelled(true);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            // mcMMO might not be present or API changed; fail silently
+            return false;
+        }
+    }
+}

--- a/src/main/java/at/sleazlee/bmessentials/TreeFeller/TreeFellerManager.java
+++ b/src/main/java/at/sleazlee/bmessentials/TreeFeller/TreeFellerManager.java
@@ -1,0 +1,71 @@
+package at.sleazlee.bmessentials.TreeFeller;
+
+import at.sleazlee.bmessentials.BMEssentials;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.node.Node;
+import net.luckperms.api.node.types.PermissionNode;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Handles tracking of players who have automatic tree felling enabled
+ * and registers the toggle command and listener.
+ */
+public class TreeFellerManager {
+    static final String PERMISSION = "bmessentials.treefeller.use";
+
+    private final BMEssentials plugin;
+    private LuckPerms luckPerms;
+
+    public TreeFellerManager(BMEssentials plugin) {
+        this.plugin = plugin;
+        setupLuckPerms();
+        plugin.getCommand("treefeller").setExecutor(new ToggleCommand(this));
+        Bukkit.getPluginManager().registerEvents(new TreeFellerListener(this), plugin);
+    }
+
+    private void setupLuckPerms() {
+        try {
+            this.luckPerms = LuckPermsProvider.get();
+        } catch (IllegalStateException e) {
+            plugin.getLogger().warning("LuckPerms not available; TreeFeller toggle will not persist.");
+        }
+    }
+
+    BMEssentials getPlugin() {
+        return plugin;
+    }
+
+    boolean isEnabled(Player player) {
+        if (luckPerms == null) {
+            return true;
+        }
+        return luckPerms.getPlayerAdapter(Player.class).getPermissionData(player)
+                .checkPermission(PERMISSION).asBoolean();
+    }
+
+    void toggle(Player player) {
+        if (luckPerms == null) {
+            player.sendMessage("LuckPerms not loaded, cannot toggle TreeFeller.");
+            return;
+        }
+
+        User user = luckPerms.getPlayerAdapter(Player.class).getUser(player);
+        boolean currently = isEnabled(player);
+
+        // Remove existing nodes for this permission
+        user.data().clear(node -> node.getKey().equals(PERMISSION));
+
+        if (!currently) {
+            Node node = PermissionNode.builder(PERMISSION).value(true).build();
+            user.data().add(node);
+        } else {
+            Node node = PermissionNode.builder(PERMISSION).value(false).build();
+            user.data().add(node);
+        }
+
+        luckPerms.getUserManager().saveUser(user);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -240,6 +240,12 @@ Systems:
   AFKSystem:
     Enabled: true
 
+  # Enables automatic tree felling when chopping logs
+  # Players can toggle with /treefeller if they have
+  # permission bmessentials.treefeller.use
+  TreeFeller:
+    Enabled: true
+
   # Enables the Lands TP Fix System
   LandsTPFix:
     Enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -238,6 +238,9 @@ commands:
     description: Shows when a player was last online.
     usage: /seen <player>
 
+  treefeller:
+    description: Toggle automatic tree felling.
+
   bms:
     description: Manage Block Miner shops.
     usage: /bms <buy [shop]|disband|invite|remove|transfer|extend|rename|tp|admin>
@@ -279,3 +282,6 @@ permissions:
   bmessentials.wild.admin:
     description: Allows use of /wild admin commands.
     default: op
+  bmessentials.treefeller.use:
+    description: Allows automatic tree felling when chopping logs.
+    default: true


### PR DESCRIPTION
## Summary
- create TreeFellerManager, ToggleCommand, and TreeFellerListener
- integrate TreeFeller system in BMEssentials main class
- add command entry for `/treefeller`
- add configuration toggle for TreeFeller
- cache mcMMO reflection lookups
- cancel block break only when TreeFeller succeeds
- store per-player toggle state using LuckPerms permissions
- skip placed logs when invoking mcMMO Tree Feller

## Testing
- `mvn -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861bf91561c8332947c0f5296f89bf2