### PR TITLE
Fix async command issues on Folia

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/DonationSystem/GetDonations.java
+++ b/src/main/java/at/sleazlee/bmessentials/DonationSystem/GetDonations.java
@@ -1,6 +1,7 @@
 package at.sleazlee.bmessentials.DonationSystem;
 
 import at.sleazlee.bmessentials.BMEssentials;
+import at.sleazlee.bmessentials.Scheduler;
 import at.sleazlee.bmessentials.crypto.AESEncryptor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
@@ -52,7 +53,7 @@ public class GetDonations implements PluginMessageListener {
         String playerName = parts[0];
         String donationPackage = parts[1];
 
-        // 4) Process the donation command
-        donationCommand.processDonationCommand(playerName, donationPackage);
+        // 4) Process the donation command on the main thread
+        Scheduler.run(() -> donationCommand.processDonationCommand(playerName, donationPackage));
     }
 }

--- a/src/main/java/at/sleazlee/bmessentials/Punish/VelocityMutePlayer.java
+++ b/src/main/java/at/sleazlee/bmessentials/Punish/VelocityMutePlayer.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
+import at.sleazlee.bmessentials.Scheduler;
 
 public class VelocityMutePlayer implements PluginMessageListener {
 
@@ -38,8 +39,10 @@ public class VelocityMutePlayer implements PluginMessageListener {
 
 		plugin.getLogger().info("Received the message: " + muteCommandBuilder);
 
-		ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
-		Bukkit.dispatchCommand(console, muteCommandBuilder);
+                ConsoleCommandSender console = Bukkit.getServer().getConsoleSender();
+
+                // Execute the mute command on the main thread to satisfy Folia
+                Scheduler.run(() -> Bukkit.dispatchCommand(console, muteCommandBuilder));
 
 	}
 }

--- a/src/main/java/at/sleazlee/bmessentials/votesystem/BMVote.java
+++ b/src/main/java/at/sleazlee/bmessentials/votesystem/BMVote.java
@@ -120,10 +120,12 @@ public class BMVote implements CommandExecutor, PluginMessageListener {
             return;
         }
 
-        // 4) Award the votes
-        for (int i = 0; i < voteCount; i++) {
-            givePrizeByUUID(uuidString);
-        }
+        // 4) Award the votes on the main thread
+        Scheduler.run(() -> {
+            for (int i = 0; i < voteCount; i++) {
+                givePrizeByUUID(uuidString);
+            }
+        });
     }
 
 


### PR DESCRIPTION
## Summary
- run Folia plugin message actions on the main thread
- update donation, vote and mute features to schedule commands via the custom Scheduler

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6867fb4463b48332a0b2c0b2e97e6ee3