### PR TITLE
Add ImageMaps tiling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ This plugin allows you to convert images into in‑game maps using the `/imagema
 
 ## Image size
 - Minecraft maps are always 128x128 pixels. The plugin will scale your image to the dimensions provided with the command (defaults are `DefaultWidth` and `DefaultHeight` in `config.yml`).
-- For the most predictable output, prepare your image at 128x128 pixels so no scaling is needed.
+- If the scaled image is larger than 128 pixels in either direction and is divisible by 128, `/imagemap` automatically divides it into multiple maps.
+- For the most predictable output, prepare your image so its width and height are multiples of 128.
 ---
 
 ## Contributing

--- a/src/main/java/at/sleazlee/bmessentials/ImageMaps/ImageMapCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/ImageMaps/ImageMapCommand.java
@@ -9,6 +9,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapView;
 
+import javax.imageio.ImageIO;
+import java.io.File;
+
 import java.awt.image.BufferedImage;
 
 /**
@@ -32,31 +35,78 @@ public class ImageMapCommand implements CommandExecutor {
             return true;
         }
         String filename = args[0];
-        int defW = plugin.getConfig().getInt("Systems.ImageMaps.DefaultWidth", 128);
-        int defH = plugin.getConfig().getInt("Systems.ImageMaps.DefaultHeight", 128);
-        int width = defW;
-        int height = defH;
-        if (args.length > 1) {
-            try { width = Integer.parseInt(args[1]); } catch (NumberFormatException ignore) {}
+
+        File imgDir = new File(plugin.getDataFolder(), "Images");
+        File file = new File(imgDir, filename);
+        if (!file.exists()) {
+            player.sendMessage(ChatColor.RED + "Image not found: " + filename);
+            return true;
         }
-        if (args.length > 2) {
-            try { height = Integer.parseInt(args[2]); } catch (NumberFormatException ignore) {}
+
+        if (plugin.getImageMapManager().hasImage(filename)) {
+            for (int id : plugin.getImageMapManager().getMapIds(filename)) {
+                MapCreator.giveExistingMap(player, id);
+            }
+            player.sendMessage(ChatColor.GREEN + "Loaded existing maps for " + filename + ".");
+            return true;
         }
+
+        BufferedImage original;
+        try {
+            original = ImageIO.read(file);
+        } catch (Exception e) {
+            player.sendMessage(ChatColor.RED + "Failed to read image: " + e.getMessage());
+            return true;
+        }
+        if (original == null) {
+            player.sendMessage(ChatColor.RED + "Unsupported image format.");
+            return true;
+        }
+
+        int width = args.length > 1 ? parseIntOr(args[1], original.getWidth()) : original.getWidth();
+        int height = args.length > 2 ? parseIntOr(args[2], original.getHeight()) : original.getHeight();
+
+        if (width % 128 != 0 || height % 128 != 0) {
+            player.sendMessage(ChatColor.RED + "Width and height must be divisible by 128.");
+            return true;
+        }
+
         player.sendMessage(ChatColor.GRAY + "Processing image...");
         int w = width;
         int h = height;
+
         Scheduler.runAsync(() -> {
             try {
                 BufferedImage img = ImageLoader.load(plugin, filename, w, h);
-                int[] pixels = Ditherer.dither(img);          // NEW: int[], not byte[]
+                int tilesX = w / 128;
+                int tilesY = h / 128;
+                java.util.List<int[]> slices = new java.util.ArrayList<>();
+                for (int ty = 0; ty < tilesY; ty++) {
+                    for (int tx = 0; tx < tilesX; tx++) {
+                        BufferedImage part = img.getSubimage(tx * 128, ty * 128, 128, 128);
+                        slices.add(Ditherer.dither(part));
+                    }
+                }
                 Scheduler.run(() -> {
-                    MapView view = MapCreator.giveMap(player, pixels);
-                    plugin.getImageMapManager().registerMap(view.getId(), filename, w, h);
+                    java.util.List<Integer> ids = new java.util.ArrayList<>();
+                    for (int[] pixels : slices) {
+                        MapView view = MapCreator.giveMap(player, pixels);
+                        ids.add(view.getId());
+                    }
+                    plugin.getImageMapManager().registerImage(filename, w, h, ids);
                 });
             } catch (Exception e) {
                 Scheduler.run(() -> player.sendMessage(ChatColor.RED + "Failed: " + e.getMessage()));
             }
         });
         return true;
+    }
+
+    private int parseIntOr(String s, int fallback) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException ignore) {
+            return fallback;
+        }
     }
 }

--- a/src/main/java/at/sleazlee/bmessentials/ImageMaps/ImageMapManager.java
+++ b/src/main/java/at/sleazlee/bmessentials/ImageMaps/ImageMapManager.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.map.MapView;
+import java.util.List;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -34,55 +35,64 @@ public class ImageMapManager {
     }
 
     /**
-     * Load all saved maps and reapply their renderers.
+     * Load all saved image maps and reapply their renderers.
      */
     public void loadMaps() {
-        if (!config.isConfigurationSection("maps")) {
+        if (!config.isConfigurationSection("images")) {
             return;
         }
-        Set<String> keys = config.getConfigurationSection("maps").getKeys(false);
-        for (String key : keys) {
-            try {
-                int id = Integer.parseInt(key);
-                String path = "maps." + key + ".";
-                String filename = config.getString(path + "file");
-                int width = config.getInt(path + "width", 128);
-                int height = config.getInt(path + "height", 128);
-                MapView view = Bukkit.getMap(id);
-                if (view == null || filename == null) continue;
+        Set<String> files = config.getConfigurationSection("images").getKeys(false);
+        for (String filename : files) {
+            String base = "images." + filename + ".";
+            int width = config.getInt(base + "width", 128);
+            int height = config.getInt(base + "height", 128);
+            List<Integer> ids = config.getIntegerList(base + "maps");
+            if (ids.isEmpty()) continue;
 
+            try {
                 BufferedImage img = ImageLoader.load(plugin, filename, width, height);
-                int[] pixels = Ditherer.dither(img);
-                view.getRenderers().clear();
-                view.addRenderer(new ImageMapRenderer(pixels));
+                int tilesX = width / 128;
+                for (int i = 0; i < ids.size(); i++) {
+                    int id = ids.get(i);
+                    MapView view = Bukkit.getMap(id);
+                    if (view == null) continue;
+
+                    int sx = (i % tilesX) * 128;
+                    int sy = (i / tilesX) * 128;
+                    BufferedImage part = img.getSubimage(sx, sy, 128, 128);
+                    int[] pixels = Ditherer.dither(part);
+                    view.getRenderers().clear();
+                    view.addRenderer(new ImageMapRenderer(pixels));
+                }
             } catch (Exception ex) {
-                plugin.getLogger().warning("Failed to load image map " + key + ": " + ex.getMessage());
+                plugin.getLogger().warning("Failed to load image maps for " + filename + ": " + ex.getMessage());
             }
         }
     }
 
     /**
-     * Persist information about a new map and apply its renderer immediately.
+     * Persist information about a set of maps that make up an image.
      */
-    public void registerMap(int mapId, String filename, int width, int height) {
-        String path = "maps." + mapId + ".";
-        config.set(path + "file", filename);
-        config.set(path + "width", width);
-        config.set(path + "height", height);
+    public void registerImage(String filename, int width, int height, List<Integer> mapIds) {
+        String base = "images." + filename + ".";
+        config.set(base + "width", width);
+        config.set(base + "height", height);
+        config.set(base + "maps", mapIds);
         saveConfig();
+    }
 
-        // Apply renderer now
-        try {
-            MapView view = Bukkit.getMap(mapId);
-            if (view != null) {
-                BufferedImage img = ImageLoader.load(plugin, filename, width, height);
-                int[] pixels = Ditherer.dither(img);
-                view.getRenderers().clear();
-                view.addRenderer(new ImageMapRenderer(pixels));
-            }
-        } catch (Exception ex) {
-            plugin.getLogger().warning("Failed to register image map " + mapId + ": " + ex.getMessage());
-        }
+    /**
+     * Returns true if the given file was already processed into maps.
+     */
+    public boolean hasImage(String filename) {
+        return config.isConfigurationSection("images." + filename);
+    }
+
+    /**
+     * Gets the list of map ids associated with the given file.
+     */
+    public List<Integer> getMapIds(String filename) {
+        return config.getIntegerList("images." + filename + ".maps");
     }
 
     private void saveConfig() {

--- a/src/main/java/at/sleazlee/bmessentials/ImageMaps/MapCreator.java
+++ b/src/main/java/at/sleazlee/bmessentials/ImageMaps/MapCreator.java
@@ -24,4 +24,24 @@ public final class MapCreator {
         player.getInventory().addItem(map);
         return view;
     }
+
+    /**
+     * Gives the player an item of an already existing map.
+     *
+     * @param player the player to give the map item to
+     * @param mapId  the id of the existing map
+     */
+    public static void giveExistingMap(Player player, int mapId) {
+        MapView view = Bukkit.getMap(mapId);
+        if (view == null) {
+            return;
+        }
+
+        ItemStack map = new ItemStack(Material.FILLED_MAP);
+        MapMeta meta = (MapMeta) map.getItemMeta();
+        meta.setMapView(view);
+        map.setItemMeta(meta);
+
+        player.getInventory().addItem(map);
+    }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -242,7 +242,7 @@ commands:
     description: Manage Block Miner shops.
     usage: /bms <buy [shop]|disband|invite|remove|transfer|extend|rename|tp|admin>
   imagemap:
-    description: Render an image to a map.
+    description: Render an image to one or more maps.
     usage: /imagemap <filename> [width] [height]
 
 


### PR DESCRIPTION
## Summary
- enhance ImageMap plugin to reuse maps
- automatically split larger images into 128x128 maps
- add convenience method to give existing maps
- update README and plugin.yml

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68686c6f58d08332b1ed8add0d4afac4