### PR TITLE
Replace deprecated API usage and add explicit getters

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -63,7 +63,6 @@ import at.sleazlee.bmessentials.playerutils.InvseeTabCompleter;
 import at.sleazlee.bmessentials.playerutils.SeenCommand;
 import at.sleazlee.bmessentials.ImageMaps.ImageMapManager;
 import com.sk89q.worldguard.protection.flags.StringFlag;
-import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -103,20 +102,13 @@ public class BMEssentials extends JavaPlugin {
     /** Database storing pregenerated wild locations. */
     private WildLocationsDatabase wildDB;
 
-    /** The database for the PlayerData system.
-     * -- GETTER --
-     *  Gets the instance of the DatabaseManager.
-     *
-     * @return the database manager
-     */
-    @Getter
+    /** The database for the PlayerData system. */
     private PlayerDatabaseManager PlayerDataDBManager;
 
     /** The menu GUI for the trophy system. */
     private TrophyMenu trophyGUI;
 
     private CommandQueueManager queueManager;
-    @Getter
     private ImageMapManager imageMapManager;
     private FileConfiguration config;
     private GivingTree givingTree;
@@ -723,6 +715,14 @@ public class BMEssentials extends JavaPlugin {
 
         // Log a message to indicate the plugin has been successfully disabled
         getLogger().info("BMEssentials has been disabled!");
+    }
+
+    public PlayerDatabaseManager getPlayerDataDBManager() {
+        return PlayerDataDBManager;
+    }
+
+    public ImageMapManager getImageMapManager() {
+        return imageMapManager;
     }
 
     public HelpBooks getBooks() {

--- a/src/main/java/at/sleazlee/bmessentials/Combinations/AnvilCombinationListener.java
+++ b/src/main/java/at/sleazlee/bmessentials/Combinations/AnvilCombinationListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.PrepareAnvilEvent;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.view.AnvilView;
 
 /**
  * Listens for anvil prepares and applies custom combinations when matched.
@@ -33,7 +34,7 @@ public class AnvilCombinationListener implements Listener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
-        if (!(event.getInventory() instanceof AnvilInventory inv)) {
+        if (!(event.getInventory() instanceof AnvilInventory inv) || !(event.getView() instanceof AnvilView view)) {
             return;
         }
         if (event.getRawSlot() != 2) {
@@ -51,7 +52,7 @@ public class AnvilCombinationListener implements Listener {
         event.setCancelled(true);
         inv.setItem(0, null);
         inv.setItem(1, null);
-        inv.setRepairCost(0);
+        view.setRepairCost(0);
         ItemStack result = combo.getResult();
         if (event.isShiftClick()) {
             Player player = (Player) event.getWhoClicked();

--- a/src/main/java/at/sleazlee/bmessentials/votesystem/BMVote.java
+++ b/src/main/java/at/sleazlee/bmessentials/votesystem/BMVote.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -222,13 +223,16 @@ public class BMVote implements CommandExecutor, PluginMessageListener {
 
                 // play a sound
                 String soundName = plugin.getConfig().getString("Systems.VoteSystem.Sounds");
-
-                try {
-                    Sound sound = Sound.valueOf(soundName); // Convert the string to a Sound
-                    player.getWorld().playSound(location, sound, 1f, 1f); // Play the sound
-                } catch (IllegalArgumentException e) {
-                    // If the soundName is not a valid Sound, this exception will be thrown.
-                    // You can add your error handling code here. For example:
+                NamespacedKey key = null;
+                if (soundName != null) {
+                    key = soundName.contains(":")
+                            ? NamespacedKey.fromString(soundName)
+                            : NamespacedKey.minecraft(soundName.toLowerCase(Locale.ROOT).replace('_', '.'));
+                }
+                Sound sound = key != null ? Registry.SOUNDS.get(key) : null;
+                if (sound != null) {
+                    player.getWorld().playSound(location, sound, 1f, 1f);
+                } else {
                     System.err.println("Invalid sound name in config: " + soundName);
                 }
 

--- a/src/main/java/at/sleazlee/bmessentials/wild/NoFallDamage.java
+++ b/src/main/java/at/sleazlee/bmessentials/wild/NoFallDamage.java
@@ -1,7 +1,6 @@
 package at.sleazlee.bmessentials.wild;
 
 import at.sleazlee.bmessentials.Scheduler;
-import lombok.Getter;
 import net.william278.huskhomes.event.TeleportEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -19,8 +18,11 @@ import java.util.UUID;
  */
 public class NoFallDamage implements Listener {
 
-    @Getter
     private static final List<UUID> fallDisabled = new ArrayList<>(); // List of player UUIDs with fall damage disabled.
+
+    public static List<UUID> getFallDisabled() {
+        return fallDisabled;
+    }
 
 
     /**


### PR DESCRIPTION
## Summary
- Switch anvil repair cost handling to `AnvilView#setRepairCost`.
- Provide explicit getters for `PlayerDatabaseManager` and `ImageMapManager`.
- Expose fall-damage exemption list via new accessor in `NoFallDamage`.
- Use `Registry.SOUNDS` to resolve sound names for vote rewards.

## Testing
- `mvn -q -e -DskipTests package` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab037b348332ac769e72672356df