### PR TITLE
Add configurable Giving Tree action bar messages

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -162,6 +162,11 @@ Systems:
   # Enables the Giving Tree system.
   Containers:
     Enabled: true
+    GivingTree:
+      SuccessMessages:
+        - '<green>Yeah! You got it!</green>'
+      FailureMessages:
+        - '<#ff3300>Oops! Too late...</#ff3300>'
 
   # Allows applying unsafe enchantment books to items using anvils.
   CombineSystem:


### PR DESCRIPTION
## Summary
- load configurable success and failure action bar messages for the Giving Tree
- fall back to default phrases and send a random entry from each list when players claim items
- ship default message lists in the configuration file

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc604c43883328a65b54c32c43d1b