### PR TITLE
Add warnban command using MiniMessage formatting

### DIFF
--- a/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
+++ b/src/main/java/at/sleazlee/bmessentials/BMEssentials.java
@@ -36,6 +36,7 @@ import at.sleazlee.bmessentials.PlayerData.PlayerJoinListener;
 import at.sleazlee.bmessentials.Punish.AutoBanCommand;
 import at.sleazlee.bmessentials.Punish.UnMuteCommand;
 import at.sleazlee.bmessentials.Punish.VelocityMutePlayer;
+import at.sleazlee.bmessentials.Punish.WarnBanCommand;
 import at.sleazlee.bmessentials.PurpurFeatures.*;
 import at.sleazlee.bmessentials.SpawnSystems.FirstJoinCommand;
 import at.sleazlee.bmessentials.SimplePortals.SimplePortals;
@@ -434,6 +435,7 @@ public class BMEssentials extends JavaPlugin {
             // Register the commands used for punishing players
             getCommand("autoban").setExecutor(new AutoBanCommand(this));
             getCommand("unmute").setExecutor(new UnMuteCommand());
+            getCommand("warnban").setExecutor(new WarnBanCommand());
 
             // Plugin messaging: send autoban requests to Velocity and receive mute commands
             getServer().getMessenger().registerOutgoingPluginChannel(this, "bmessentials:autoban");

--- a/src/main/java/at/sleazlee/bmessentials/Punish/WarnBanCommand.java
+++ b/src/main/java/at/sleazlee/bmessentials/Punish/WarnBanCommand.java
@@ -1,0 +1,63 @@
+package at.sleazlee.bmessentials.Punish;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+
+/**
+ * Sends a formatted warning message to a player using MiniMessage formatting.
+ */
+public class WarnBanCommand implements CommandExecutor {
+
+    private static final String PERMISSION = "bm.staff.warnban";
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!label.equalsIgnoreCase("warnban")) {
+            return false;
+        }
+
+        if (args.length < 2) {
+            sender.sendMessage("§c§lBM §fUsage: /warnban <player> <message>");
+            return true;
+        }
+
+        if (sender instanceof Player player && !player.hasPermission(PERMISSION)) {
+            sender.sendMessage("§c§lBM §cAccess Denied.");
+            return true;
+        }
+
+        Player target = Bukkit.getPlayerExact(args[0]);
+        if (target == null) {
+            sender.sendMessage("§c§lBM §fPlayer §e" + args[0] + " §fis not online.");
+            return true;
+        }
+
+        String message = String.join(" ", Arrays.copyOfRange(args, 1, args.length));
+
+        Component component;
+        try {
+            component = miniMessage.deserialize(message);
+        } catch (IllegalArgumentException ex) {
+            sender.sendMessage("§c§lBM §fInvalid MiniMessage format. Please check your tags.");
+            return true;
+        }
+
+        target.sendMessage(component);
+
+        if (!sender.equals(target)) {
+            Component confirmation = miniMessage.deserialize("<green><bold>WarnBan </bold></green><gray>Sent message to <yellow>"
+                    + target.getName() + "</yellow>.</gray>");
+            sender.sendMessage(confirmation);
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -134,6 +134,12 @@ commands:
     description: Unmutes a player.
     usage: /unmute <player>
 
+  warnban:
+    description: Sends a formatted warning message to a player.
+    usage: /warnban <player> <message>
+    permission: bm.staff.warnban
+    permission-message: '&cYou do not have permission to use this command.'
+
   donation:
     description: Give a selected player the selected donation package.
     usage: /donation <player> <package>


### PR DESCRIPTION
## Summary
- add a /warnban command that delivers MiniMessage-formatted warnings to targeted players
- register the warnban command in the punishment system and expose its configuration entry with a dedicated permission

## Testing
- mvn -DskipTests package *(fails to complete because of extensive dependency downloads in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ffc3b15c8332b90e31a68f3600b6